### PR TITLE
DM swap

### DIFF
--- a/fpga/orangecrab_litedram/litedram_core.v
+++ b/fpga/orangecrab_litedram/litedram_core.v
@@ -8,7 +8,7 @@
 //
 // Filename   : litedram_core.v
 // Device     : LFE5U-25F-8MG285C
-// LiteX sha1 : 7e6418900abc
+// LiteX sha1 : 4353135f
 // Date       : 2023-11-06 17:52:25
 //------------------------------------------------------------------------------
 
@@ -82,20 +82,6 @@ module litedram_core (
 reg           aborted = 1'd0;
 reg           aborted_litedramwishbone2native_next_value = 1'd0;
 reg           aborted_litedramwishbone2native_next_value_ce = 1'd0;
-reg     [2:0] array_muxed0 = 3'd0;
-reg    [12:0] array_muxed1 = 13'd0;
-reg           array_muxed10 = 1'd0;
-reg           array_muxed11 = 1'd0;
-reg           array_muxed12 = 1'd0;
-reg           array_muxed13 = 1'd0;
-reg           array_muxed2 = 1'd0;
-reg           array_muxed3 = 1'd0;
-reg           array_muxed4 = 1'd0;
-reg           array_muxed5 = 1'd0;
-reg           array_muxed6 = 1'd0;
-reg     [2:0] array_muxed7 = 3'd0;
-reg    [12:0] array_muxed8 = 13'd0;
-reg           array_muxed9 = 1'd0;
 wire          crg_clkin;
 wire          crg_clkout0;
 wire          crg_clkout1;
@@ -267,7 +253,6 @@ reg           ddrphy_burstdet_d1 = 1'd0;
 reg           ddrphy_burstdet_seen_re = 1'd0;
 reg     [1:0] ddrphy_burstdet_seen_status = 2'd0;
 wire          ddrphy_burstdet_seen_we;
-reg     [6:0] ddrphy_counter = 7'd0;
 wire    [1:0] ddrphy_datavalid;
 wire          ddrphy_delay0;
 wire          ddrphy_delay1;
@@ -540,6 +525,7 @@ wire          ddrphy_reset0;
 reg           ddrphy_reset1 = 1'd0;
 wire          ddrphy_stop0;
 reg           ddrphy_stop1 = 1'd0;
+reg     [6:0] ddrphy_trigger = 7'd0;
 reg           ddrphy_update = 1'd0;
 reg           ddrphy_wrdata_en_tappeddelayline0 = 1'd0;
 reg           ddrphy_wrdata_en_tappeddelayline1 = 1'd0;
@@ -1724,11 +1710,11 @@ wire          litedramcore_read_available;
 wire          litedramcore_reset_n;
 wire          litedramcore_sel;
 reg           litedramcore_sequencer_count = 1'd0;
-reg     [6:0] litedramcore_sequencer_counter = 7'd0;
 wire          litedramcore_sequencer_done0;
 reg           litedramcore_sequencer_done1 = 1'd0;
 reg           litedramcore_sequencer_start0 = 1'd0;
 wire          litedramcore_sequencer_start1;
+reg     [6:0] litedramcore_sequencer_trigger = 7'd0;
 wire          litedramcore_slave_p0_act_n;
 wire   [12:0] litedramcore_slave_p0_address;
 wire    [2:0] litedramcore_slave_p0_bank;
@@ -1761,12 +1747,12 @@ wire          litedramcore_slave_p1_we_n;
 wire   [63:0] litedramcore_slave_p1_wrdata;
 wire          litedramcore_slave_p1_wrdata_en;
 wire    [7:0] litedramcore_slave_p1_wrdata_mask;
-reg           litedramcore_steerer0 = 1'd1;
-reg           litedramcore_steerer1 = 1'd1;
+reg     [1:0] litedramcore_steerer0 = 2'd0;
+reg     [1:0] litedramcore_steerer1 = 2'd0;
 reg           litedramcore_steerer2 = 1'd1;
 reg           litedramcore_steerer3 = 1'd1;
-reg     [1:0] litedramcore_steerer_sel0 = 2'd0;
-reg     [1:0] litedramcore_steerer_sel1 = 2'd0;
+reg           litedramcore_steerer4 = 1'd1;
+reg           litedramcore_steerer5 = 1'd1;
 reg     [3:0] litedramcore_storage = 4'd1;
 reg           litedramcore_tccdcon_count = 1'd0;
 reg           litedramcore_tccdcon_ready = 1'd0;
@@ -1805,9 +1791,9 @@ wire    [3:0] litedramcore_wishbone_sel;
 wire          litedramcore_wishbone_stb;
 wire          litedramcore_wishbone_we;
 wire          litedramcore_write_available;
-reg     [5:0] litedramcore_zqcs_executer_counter = 6'd0;
 reg           litedramcore_zqcs_executer_done = 1'd0;
 reg           litedramcore_zqcs_executer_start = 1'd0;
+reg     [5:0] litedramcore_zqcs_executer_trigger = 6'd0;
 wire   [25:0] litedramcore_zqcs_timer_count0;
 reg    [25:0] litedramcore_zqcs_timer_count1 = 26'd49999999;
 wire          litedramcore_zqcs_timer_done0;
@@ -2003,6 +1989,8 @@ wire   [37:0] litedramnativeportconverter_wdata_fifo_wrport_dat_w;
 wire          litedramnativeportconverter_wdata_fifo_wrport_we;
 wire          litedramnativeportconverter_wdata_finished;
 reg    [15:0] litedramnativeportconverter_wdata_sel = 16'd0;
+reg           multiregimpl0 = 1'd0;
+reg           multiregimpl1 = 1'd0;
 wire          new_port_cmd_last;
 wire   [24:0] new_port_cmd_payload_addr;
 wire          new_port_cmd_payload_we;
@@ -2034,55 +2022,67 @@ wire  [127:0] port_wdata_payload_data;
 wire   [15:0] port_wdata_payload_we;
 wire          port_wdata_ready;
 wire          port_wdata_valid;
-reg           regs0 = 1'd0;
-reg           regs1 = 1'd0;
-reg           rhs_array_muxed0 = 1'd0;
-reg    [12:0] rhs_array_muxed1 = 13'd0;
-reg           rhs_array_muxed10 = 1'd0;
-reg           rhs_array_muxed11 = 1'd0;
-reg    [19:0] rhs_array_muxed12 = 20'd0;
-reg           rhs_array_muxed13 = 1'd0;
-reg           rhs_array_muxed14 = 1'd0;
-reg    [19:0] rhs_array_muxed15 = 20'd0;
-reg           rhs_array_muxed16 = 1'd0;
-reg           rhs_array_muxed17 = 1'd0;
-reg    [19:0] rhs_array_muxed18 = 20'd0;
-reg           rhs_array_muxed19 = 1'd0;
-reg     [2:0] rhs_array_muxed2 = 3'd0;
-reg           rhs_array_muxed20 = 1'd0;
-reg    [19:0] rhs_array_muxed21 = 20'd0;
-reg           rhs_array_muxed22 = 1'd0;
-reg           rhs_array_muxed23 = 1'd0;
-reg    [19:0] rhs_array_muxed24 = 20'd0;
-reg           rhs_array_muxed25 = 1'd0;
-reg           rhs_array_muxed26 = 1'd0;
-reg    [19:0] rhs_array_muxed27 = 20'd0;
-reg           rhs_array_muxed28 = 1'd0;
-reg           rhs_array_muxed29 = 1'd0;
-reg           rhs_array_muxed3 = 1'd0;
-reg    [19:0] rhs_array_muxed30 = 20'd0;
-reg           rhs_array_muxed31 = 1'd0;
-reg           rhs_array_muxed32 = 1'd0;
-reg    [19:0] rhs_array_muxed33 = 20'd0;
-reg           rhs_array_muxed34 = 1'd0;
-reg           rhs_array_muxed35 = 1'd0;
-reg           rhs_array_muxed4 = 1'd0;
-reg           rhs_array_muxed5 = 1'd0;
-reg           rhs_array_muxed6 = 1'd0;
-reg    [12:0] rhs_array_muxed7 = 13'd0;
-reg     [2:0] rhs_array_muxed8 = 3'd0;
-reg           rhs_array_muxed9 = 1'd0;
+reg           rhs_self0 = 1'd0;
+reg    [12:0] rhs_self1 = 13'd0;
+reg           rhs_self10 = 1'd0;
+reg           rhs_self11 = 1'd0;
+reg    [19:0] rhs_self12 = 20'd0;
+reg           rhs_self13 = 1'd0;
+reg           rhs_self14 = 1'd0;
+reg    [19:0] rhs_self15 = 20'd0;
+reg           rhs_self16 = 1'd0;
+reg           rhs_self17 = 1'd0;
+reg    [19:0] rhs_self18 = 20'd0;
+reg           rhs_self19 = 1'd0;
+reg     [2:0] rhs_self2 = 3'd0;
+reg           rhs_self20 = 1'd0;
+reg    [19:0] rhs_self21 = 20'd0;
+reg           rhs_self22 = 1'd0;
+reg           rhs_self23 = 1'd0;
+reg    [19:0] rhs_self24 = 20'd0;
+reg           rhs_self25 = 1'd0;
+reg           rhs_self26 = 1'd0;
+reg    [19:0] rhs_self27 = 20'd0;
+reg           rhs_self28 = 1'd0;
+reg           rhs_self29 = 1'd0;
+reg           rhs_self3 = 1'd0;
+reg    [19:0] rhs_self30 = 20'd0;
+reg           rhs_self31 = 1'd0;
+reg           rhs_self32 = 1'd0;
+reg    [19:0] rhs_self33 = 20'd0;
+reg           rhs_self34 = 1'd0;
+reg           rhs_self35 = 1'd0;
+reg           rhs_self4 = 1'd0;
+reg           rhs_self5 = 1'd0;
+reg           rhs_self6 = 1'd0;
+reg    [12:0] rhs_self7 = 13'd0;
+reg     [2:0] rhs_self8 = 3'd0;
+reg           rhs_self9 = 1'd0;
+reg     [2:0] self0 = 3'd0;
+reg    [12:0] self1 = 13'd0;
+reg           self10 = 1'd0;
+reg           self11 = 1'd0;
+reg           self12 = 1'd0;
+reg           self13 = 1'd0;
+reg           self2 = 1'd0;
+reg           self3 = 1'd0;
+reg           self4 = 1'd0;
+reg           self5 = 1'd0;
+reg           self6 = 1'd0;
+reg     [2:0] self7 = 3'd0;
+reg    [12:0] self8 = 13'd0;
+reg           self9 = 1'd0;
 wire          sys2x_clk;
 wire          sys2x_i_clk;
 wire          sys2x_rst;
 wire          sys_clk;
 wire          sys_rst;
-reg           t_array_muxed0 = 1'd0;
-reg           t_array_muxed1 = 1'd0;
-reg           t_array_muxed2 = 1'd0;
-reg           t_array_muxed3 = 1'd0;
-reg           t_array_muxed4 = 1'd0;
-reg           t_array_muxed5 = 1'd0;
+reg           t_self0 = 1'd0;
+reg           t_self1 = 1'd0;
+reg           t_self2 = 1'd0;
+reg           t_self3 = 1'd0;
+reg           t_self4 = 1'd0;
+reg           t_self5 = 1'd0;
 reg           user_enable = 1'd0;
 wire          wb_bus_ack;
 wire   [29:0] wb_bus_adr;
@@ -2150,14 +2150,14 @@ assign init_clk = crg_clkout1;
 assign crg_locked = (litedramcore_litedramecp5ddrphycrg_locked & (~crg_reset1));
 always @(*) begin
     ddrphy_dm_o_data0 <= 8'd0;
-    ddrphy_dm_o_data0[0] <= ddrphy_dfi_p0_wrdata_mask[0];
-    ddrphy_dm_o_data0[1] <= ddrphy_dfi_p0_wrdata_mask[2];
-    ddrphy_dm_o_data0[2] <= ddrphy_dfi_p0_wrdata_mask[4];
-    ddrphy_dm_o_data0[3] <= ddrphy_dfi_p0_wrdata_mask[6];
-    ddrphy_dm_o_data0[4] <= ddrphy_dfi_p1_wrdata_mask[0];
-    ddrphy_dm_o_data0[5] <= ddrphy_dfi_p1_wrdata_mask[2];
-    ddrphy_dm_o_data0[6] <= ddrphy_dfi_p1_wrdata_mask[4];
-    ddrphy_dm_o_data0[7] <= ddrphy_dfi_p1_wrdata_mask[6];
+    ddrphy_dm_o_data0[0] <= ddrphy_dfi_p0_wrdata_mask[1];
+    ddrphy_dm_o_data0[1] <= ddrphy_dfi_p0_wrdata_mask[3];
+    ddrphy_dm_o_data0[2] <= ddrphy_dfi_p0_wrdata_mask[5];
+    ddrphy_dm_o_data0[3] <= ddrphy_dfi_p0_wrdata_mask[7];
+    ddrphy_dm_o_data0[4] <= ddrphy_dfi_p1_wrdata_mask[1];
+    ddrphy_dm_o_data0[5] <= ddrphy_dfi_p1_wrdata_mask[3];
+    ddrphy_dm_o_data0[6] <= ddrphy_dfi_p1_wrdata_mask[5];
+    ddrphy_dm_o_data0[7] <= ddrphy_dfi_p1_wrdata_mask[7];
 end
 always @(*) begin
     ddrphy_dq_o_data0 <= 8'd0;
@@ -2391,14 +2391,14 @@ end
 assign ddrphy_dq_i_data7 = {ddrphy_bitslip7_o, ddrphy_dq_i_bitslip_o_d7};
 always @(*) begin
     ddrphy_dm_o_data1 <= 8'd0;
-    ddrphy_dm_o_data1[0] <= ddrphy_dfi_p0_wrdata_mask[1];
-    ddrphy_dm_o_data1[1] <= ddrphy_dfi_p0_wrdata_mask[3];
-    ddrphy_dm_o_data1[2] <= ddrphy_dfi_p0_wrdata_mask[5];
-    ddrphy_dm_o_data1[3] <= ddrphy_dfi_p0_wrdata_mask[7];
-    ddrphy_dm_o_data1[4] <= ddrphy_dfi_p1_wrdata_mask[1];
-    ddrphy_dm_o_data1[5] <= ddrphy_dfi_p1_wrdata_mask[3];
-    ddrphy_dm_o_data1[6] <= ddrphy_dfi_p1_wrdata_mask[5];
-    ddrphy_dm_o_data1[7] <= ddrphy_dfi_p1_wrdata_mask[7];
+    ddrphy_dm_o_data1[0] <= ddrphy_dfi_p0_wrdata_mask[0];
+    ddrphy_dm_o_data1[1] <= ddrphy_dfi_p0_wrdata_mask[2];
+    ddrphy_dm_o_data1[2] <= ddrphy_dfi_p0_wrdata_mask[4];
+    ddrphy_dm_o_data1[3] <= ddrphy_dfi_p0_wrdata_mask[6];
+    ddrphy_dm_o_data1[4] <= ddrphy_dfi_p1_wrdata_mask[0];
+    ddrphy_dm_o_data1[5] <= ddrphy_dfi_p1_wrdata_mask[2];
+    ddrphy_dm_o_data1[6] <= ddrphy_dfi_p1_wrdata_mask[4];
+    ddrphy_dm_o_data1[7] <= ddrphy_dfi_p1_wrdata_mask[6];
 end
 always @(*) begin
     ddrphy_dq_o_data8 <= 8'd0;
@@ -6036,6 +6036,28 @@ always @(*) begin
     endcase
 end
 always @(*) begin
+    litedramcore_bankmachine4_row_open <= 1'd0;
+    case (litedramcore_litedramcore_bankmachine4_state)
+        1'd1: begin
+        end
+        2'd2: begin
+        end
+        2'd3: begin
+            if (litedramcore_bankmachine4_trccon_ready) begin
+                litedramcore_bankmachine4_row_open <= 1'd1;
+            end
+        end
+        3'd4: begin
+        end
+        3'd5: begin
+        end
+        3'd6: begin
+        end
+        default: begin
+        end
+    endcase
+end
+always @(*) begin
     litedramcore_bankmachine4_cmd_valid <= 1'd0;
     case (litedramcore_litedramcore_bankmachine4_state)
         1'd1: begin
@@ -6085,28 +6107,6 @@ always @(*) begin
         end
         3'd4: begin
             litedramcore_bankmachine4_row_close <= 1'd1;
-        end
-        3'd5: begin
-        end
-        3'd6: begin
-        end
-        default: begin
-        end
-    endcase
-end
-always @(*) begin
-    litedramcore_bankmachine4_row_open <= 1'd0;
-    case (litedramcore_litedramcore_bankmachine4_state)
-        1'd1: begin
-        end
-        2'd2: begin
-        end
-        2'd3: begin
-            if (litedramcore_bankmachine4_trccon_ready) begin
-                litedramcore_bankmachine4_row_open <= 1'd1;
-            end
-        end
-        3'd4: begin
         end
         3'd5: begin
         end
@@ -7702,28 +7702,28 @@ always @(*) begin
     litedramcore_choose_cmd_valids[7] <= (litedramcore_bankmachine7_cmd_valid & (((litedramcore_bankmachine7_cmd_payload_is_cmd & litedramcore_choose_cmd_want_cmds) & ((~((litedramcore_bankmachine7_cmd_payload_ras & (~litedramcore_bankmachine7_cmd_payload_cas)) & (~litedramcore_bankmachine7_cmd_payload_we))) | litedramcore_choose_cmd_want_activates)) | ((litedramcore_bankmachine7_cmd_payload_is_read == litedramcore_choose_cmd_want_reads) & (litedramcore_bankmachine7_cmd_payload_is_write == litedramcore_choose_cmd_want_writes))));
 end
 assign litedramcore_choose_cmd_request = litedramcore_choose_cmd_valids;
-assign litedramcore_choose_cmd_cmd_valid = rhs_array_muxed0;
-assign litedramcore_choose_cmd_cmd_payload_a = rhs_array_muxed1;
-assign litedramcore_choose_cmd_cmd_payload_ba = rhs_array_muxed2;
-assign litedramcore_choose_cmd_cmd_payload_is_read = rhs_array_muxed3;
-assign litedramcore_choose_cmd_cmd_payload_is_write = rhs_array_muxed4;
-assign litedramcore_choose_cmd_cmd_payload_is_cmd = rhs_array_muxed5;
+assign litedramcore_choose_cmd_cmd_valid = rhs_self0;
+assign litedramcore_choose_cmd_cmd_payload_a = rhs_self1;
+assign litedramcore_choose_cmd_cmd_payload_ba = rhs_self2;
+assign litedramcore_choose_cmd_cmd_payload_is_read = rhs_self3;
+assign litedramcore_choose_cmd_cmd_payload_is_write = rhs_self4;
+assign litedramcore_choose_cmd_cmd_payload_is_cmd = rhs_self5;
 always @(*) begin
     litedramcore_choose_cmd_cmd_payload_cas <= 1'd0;
     if (litedramcore_choose_cmd_cmd_valid) begin
-        litedramcore_choose_cmd_cmd_payload_cas <= t_array_muxed0;
+        litedramcore_choose_cmd_cmd_payload_cas <= t_self0;
     end
 end
 always @(*) begin
     litedramcore_choose_cmd_cmd_payload_ras <= 1'd0;
     if (litedramcore_choose_cmd_cmd_valid) begin
-        litedramcore_choose_cmd_cmd_payload_ras <= t_array_muxed1;
+        litedramcore_choose_cmd_cmd_payload_ras <= t_self1;
     end
 end
 always @(*) begin
     litedramcore_choose_cmd_cmd_payload_we <= 1'd0;
     if (litedramcore_choose_cmd_cmd_valid) begin
-        litedramcore_choose_cmd_cmd_payload_we <= t_array_muxed2;
+        litedramcore_choose_cmd_cmd_payload_we <= t_self2;
     end
 end
 always @(*) begin
@@ -7811,37 +7811,37 @@ always @(*) begin
     litedramcore_choose_req_valids[7] <= (litedramcore_bankmachine7_cmd_valid & (((litedramcore_bankmachine7_cmd_payload_is_cmd & litedramcore_choose_req_want_cmds) & ((~((litedramcore_bankmachine7_cmd_payload_ras & (~litedramcore_bankmachine7_cmd_payload_cas)) & (~litedramcore_bankmachine7_cmd_payload_we))) | litedramcore_choose_req_want_activates)) | ((litedramcore_bankmachine7_cmd_payload_is_read == litedramcore_choose_req_want_reads) & (litedramcore_bankmachine7_cmd_payload_is_write == litedramcore_choose_req_want_writes))));
 end
 assign litedramcore_choose_req_request = litedramcore_choose_req_valids;
-assign litedramcore_choose_req_cmd_valid = rhs_array_muxed6;
-assign litedramcore_choose_req_cmd_payload_a = rhs_array_muxed7;
-assign litedramcore_choose_req_cmd_payload_ba = rhs_array_muxed8;
-assign litedramcore_choose_req_cmd_payload_is_read = rhs_array_muxed9;
-assign litedramcore_choose_req_cmd_payload_is_write = rhs_array_muxed10;
-assign litedramcore_choose_req_cmd_payload_is_cmd = rhs_array_muxed11;
+assign litedramcore_choose_req_cmd_valid = rhs_self6;
+assign litedramcore_choose_req_cmd_payload_a = rhs_self7;
+assign litedramcore_choose_req_cmd_payload_ba = rhs_self8;
+assign litedramcore_choose_req_cmd_payload_is_read = rhs_self9;
+assign litedramcore_choose_req_cmd_payload_is_write = rhs_self10;
+assign litedramcore_choose_req_cmd_payload_is_cmd = rhs_self11;
 always @(*) begin
     litedramcore_choose_req_cmd_payload_cas <= 1'd0;
     if (litedramcore_choose_req_cmd_valid) begin
-        litedramcore_choose_req_cmd_payload_cas <= t_array_muxed3;
+        litedramcore_choose_req_cmd_payload_cas <= t_self3;
     end
 end
 always @(*) begin
     litedramcore_choose_req_cmd_payload_ras <= 1'd0;
     if (litedramcore_choose_req_cmd_valid) begin
-        litedramcore_choose_req_cmd_payload_ras <= t_array_muxed4;
+        litedramcore_choose_req_cmd_payload_ras <= t_self4;
     end
 end
 always @(*) begin
     litedramcore_choose_req_cmd_payload_we <= 1'd0;
     if (litedramcore_choose_req_cmd_valid) begin
-        litedramcore_choose_req_cmd_payload_we <= t_array_muxed5;
+        litedramcore_choose_req_cmd_payload_we <= t_self5;
     end
 end
 assign litedramcore_choose_req_ce = (litedramcore_choose_req_cmd_ready | (~litedramcore_choose_req_cmd_valid));
 assign litedramcore_dfi_p0_reset_n = 1'd1;
-assign litedramcore_dfi_p0_cke = {1{litedramcore_steerer0}};
-assign litedramcore_dfi_p0_odt = {1{litedramcore_steerer1}};
+assign litedramcore_dfi_p0_cke = {1{litedramcore_steerer2}};
+assign litedramcore_dfi_p0_odt = {1{litedramcore_steerer3}};
 assign litedramcore_dfi_p1_reset_n = 1'd1;
-assign litedramcore_dfi_p1_cke = {1{litedramcore_steerer2}};
-assign litedramcore_dfi_p1_odt = {1{litedramcore_steerer3}};
+assign litedramcore_dfi_p1_cke = {1{litedramcore_steerer4}};
+assign litedramcore_dfi_p1_odt = {1{litedramcore_steerer5}};
 assign litedramcore_tfawcon_count = ((litedramcore_tfawcon_window[0] + litedramcore_tfawcon_window[1]) + litedramcore_tfawcon_window[2]);
 always @(*) begin
     litedramcore_litedramcore_multiplexer_next_state <= 4'd0;
@@ -7954,19 +7954,19 @@ always @(*) begin
     endcase
 end
 always @(*) begin
-    litedramcore_steerer_sel0 <= 2'd0;
+    litedramcore_steerer0 <= 2'd0;
     case (litedramcore_litedramcore_multiplexer_state)
         1'd1: begin
-            litedramcore_steerer_sel0 <= 1'd0;
+            litedramcore_steerer0 <= 1'd0;
             if (1'd0) begin
-                litedramcore_steerer_sel0 <= 2'd2;
+                litedramcore_steerer0 <= 2'd2;
             end
             if (1'd1) begin
-                litedramcore_steerer_sel0 <= 1'd1;
+                litedramcore_steerer0 <= 1'd1;
             end
         end
         2'd2: begin
-            litedramcore_steerer_sel0 <= 2'd3;
+            litedramcore_steerer0 <= 2'd3;
         end
         2'd3: begin
         end
@@ -7995,26 +7995,26 @@ always @(*) begin
         4'd15: begin
         end
         default: begin
-            litedramcore_steerer_sel0 <= 1'd0;
+            litedramcore_steerer0 <= 1'd0;
             if (1'd1) begin
-                litedramcore_steerer_sel0 <= 2'd2;
+                litedramcore_steerer0 <= 2'd2;
             end
             if (1'd0) begin
-                litedramcore_steerer_sel0 <= 1'd1;
+                litedramcore_steerer0 <= 1'd1;
             end
         end
     endcase
 end
 always @(*) begin
-    litedramcore_steerer_sel1 <= 2'd0;
+    litedramcore_steerer1 <= 2'd0;
     case (litedramcore_litedramcore_multiplexer_state)
         1'd1: begin
-            litedramcore_steerer_sel1 <= 1'd0;
+            litedramcore_steerer1 <= 1'd0;
             if (1'd1) begin
-                litedramcore_steerer_sel1 <= 2'd2;
+                litedramcore_steerer1 <= 2'd2;
             end
             if (1'd0) begin
-                litedramcore_steerer_sel1 <= 1'd1;
+                litedramcore_steerer1 <= 1'd1;
             end
         end
         2'd2: begin
@@ -8046,12 +8046,12 @@ always @(*) begin
         4'd15: begin
         end
         default: begin
-            litedramcore_steerer_sel1 <= 1'd0;
+            litedramcore_steerer1 <= 1'd0;
             if (1'd0) begin
-                litedramcore_steerer_sel1 <= 2'd2;
+                litedramcore_steerer1 <= 2'd2;
             end
             if (1'd1) begin
-                litedramcore_steerer_sel1 <= 1'd1;
+                litedramcore_steerer1 <= 1'd1;
             end
         end
     endcase
@@ -8347,44 +8347,44 @@ always @(*) begin
 end
 assign litedramcore_litedramcore_roundrobin0_request = {(((port_cmd_payload_addr[9:7] == 1'd0) & (~(((((((litedramcore_litedramcore_locked0 | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin0_ce = ((~litedramcore_interface_bank0_valid) & (~litedramcore_interface_bank0_lock));
-assign litedramcore_interface_bank0_addr = rhs_array_muxed12;
-assign litedramcore_interface_bank0_we = rhs_array_muxed13;
-assign litedramcore_interface_bank0_valid = rhs_array_muxed14;
+assign litedramcore_interface_bank0_addr = rhs_self12;
+assign litedramcore_interface_bank0_we = rhs_self13;
+assign litedramcore_interface_bank0_valid = rhs_self14;
 assign litedramcore_litedramcore_roundrobin1_request = {(((port_cmd_payload_addr[9:7] == 1'd1) & (~(((((((litedramcore_litedramcore_locked1 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin1_ce = ((~litedramcore_interface_bank1_valid) & (~litedramcore_interface_bank1_lock));
-assign litedramcore_interface_bank1_addr = rhs_array_muxed15;
-assign litedramcore_interface_bank1_we = rhs_array_muxed16;
-assign litedramcore_interface_bank1_valid = rhs_array_muxed17;
+assign litedramcore_interface_bank1_addr = rhs_self15;
+assign litedramcore_interface_bank1_we = rhs_self16;
+assign litedramcore_interface_bank1_valid = rhs_self17;
 assign litedramcore_litedramcore_roundrobin2_request = {(((port_cmd_payload_addr[9:7] == 2'd2) & (~(((((((litedramcore_litedramcore_locked2 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin2_ce = ((~litedramcore_interface_bank2_valid) & (~litedramcore_interface_bank2_lock));
-assign litedramcore_interface_bank2_addr = rhs_array_muxed18;
-assign litedramcore_interface_bank2_we = rhs_array_muxed19;
-assign litedramcore_interface_bank2_valid = rhs_array_muxed20;
+assign litedramcore_interface_bank2_addr = rhs_self18;
+assign litedramcore_interface_bank2_we = rhs_self19;
+assign litedramcore_interface_bank2_valid = rhs_self20;
 assign litedramcore_litedramcore_roundrobin3_request = {(((port_cmd_payload_addr[9:7] == 2'd3) & (~(((((((litedramcore_litedramcore_locked3 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin3_ce = ((~litedramcore_interface_bank3_valid) & (~litedramcore_interface_bank3_lock));
-assign litedramcore_interface_bank3_addr = rhs_array_muxed21;
-assign litedramcore_interface_bank3_we = rhs_array_muxed22;
-assign litedramcore_interface_bank3_valid = rhs_array_muxed23;
+assign litedramcore_interface_bank3_addr = rhs_self21;
+assign litedramcore_interface_bank3_we = rhs_self22;
+assign litedramcore_interface_bank3_valid = rhs_self23;
 assign litedramcore_litedramcore_roundrobin4_request = {(((port_cmd_payload_addr[9:7] == 3'd4) & (~(((((((litedramcore_litedramcore_locked4 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin4_ce = ((~litedramcore_interface_bank4_valid) & (~litedramcore_interface_bank4_lock));
-assign litedramcore_interface_bank4_addr = rhs_array_muxed24;
-assign litedramcore_interface_bank4_we = rhs_array_muxed25;
-assign litedramcore_interface_bank4_valid = rhs_array_muxed26;
+assign litedramcore_interface_bank4_addr = rhs_self24;
+assign litedramcore_interface_bank4_we = rhs_self25;
+assign litedramcore_interface_bank4_valid = rhs_self26;
 assign litedramcore_litedramcore_roundrobin5_request = {(((port_cmd_payload_addr[9:7] == 3'd5) & (~(((((((litedramcore_litedramcore_locked5 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin5_ce = ((~litedramcore_interface_bank5_valid) & (~litedramcore_interface_bank5_lock));
-assign litedramcore_interface_bank5_addr = rhs_array_muxed27;
-assign litedramcore_interface_bank5_we = rhs_array_muxed28;
-assign litedramcore_interface_bank5_valid = rhs_array_muxed29;
+assign litedramcore_interface_bank5_addr = rhs_self27;
+assign litedramcore_interface_bank5_we = rhs_self28;
+assign litedramcore_interface_bank5_valid = rhs_self29;
 assign litedramcore_litedramcore_roundrobin6_request = {(((port_cmd_payload_addr[9:7] == 3'd6) & (~(((((((litedramcore_litedramcore_locked6 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin6_ce = ((~litedramcore_interface_bank6_valid) & (~litedramcore_interface_bank6_lock));
-assign litedramcore_interface_bank6_addr = rhs_array_muxed30;
-assign litedramcore_interface_bank6_we = rhs_array_muxed31;
-assign litedramcore_interface_bank6_valid = rhs_array_muxed32;
+assign litedramcore_interface_bank6_addr = rhs_self30;
+assign litedramcore_interface_bank6_we = rhs_self31;
+assign litedramcore_interface_bank6_valid = rhs_self32;
 assign litedramcore_litedramcore_roundrobin7_request = {(((port_cmd_payload_addr[9:7] == 3'd7) & (~(((((((litedramcore_litedramcore_locked7 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))))) & port_cmd_valid)};
 assign litedramcore_litedramcore_roundrobin7_ce = ((~litedramcore_interface_bank7_valid) & (~litedramcore_interface_bank7_lock));
-assign litedramcore_interface_bank7_addr = rhs_array_muxed33;
-assign litedramcore_interface_bank7_we = rhs_array_muxed34;
-assign litedramcore_interface_bank7_valid = rhs_array_muxed35;
+assign litedramcore_interface_bank7_addr = rhs_self33;
+assign litedramcore_interface_bank7_we = rhs_self34;
+assign litedramcore_interface_bank7_valid = rhs_self35;
 assign port_cmd_ready = ((((((((1'd0 | (((litedramcore_litedramcore_roundrobin0_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 1'd0) & (~(((((((litedramcore_litedramcore_locked0 | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank0_ready)) | (((litedramcore_litedramcore_roundrobin1_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 1'd1) & (~(((((((litedramcore_litedramcore_locked1 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank1_ready)) | (((litedramcore_litedramcore_roundrobin2_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 2'd2) & (~(((((((litedramcore_litedramcore_locked2 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank2_ready)) | (((litedramcore_litedramcore_roundrobin3_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 2'd3) & (~(((((((litedramcore_litedramcore_locked3 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank3_ready)) | (((litedramcore_litedramcore_roundrobin4_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 3'd4) & (~(((((((litedramcore_litedramcore_locked4 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank4_ready)) | (((litedramcore_litedramcore_roundrobin5_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 3'd5) & (~(((((((litedramcore_litedramcore_locked5 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank5_ready)) | (((litedramcore_litedramcore_roundrobin6_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 3'd6) & (~(((((((litedramcore_litedramcore_locked6 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0)))))) & litedramcore_interface_bank6_ready)) | (((litedramcore_litedramcore_roundrobin7_grant == 1'd0) & ((port_cmd_payload_addr[9:7] == 3'd7) & (~(((((((litedramcore_litedramcore_locked7 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0)))))) & litedramcore_interface_bank7_ready));
 assign port_wdata_ready = litedramcore_litedramcore_new_master_wdata_ready3;
 assign port_rdata_valid = litedramcore_litedramcore_new_master_rdata_valid13;
@@ -9137,8 +9137,20 @@ always @(*) begin
         end
         default: begin
             if ((litedramcore_wishbone_cyc & litedramcore_wishbone_stb)) begin
-                litedramcore_adr_wishbone2csr_next_value1 <= litedramcore_wishbone_adr;
+                litedramcore_adr_wishbone2csr_next_value1 <= litedramcore_wishbone_adr[29:0];
             end
+        end
+    endcase
+end
+always @(*) begin
+    litedramcore_wishbone_dat_r <= 32'd0;
+    case (litedramcore_wishbone2csr_state)
+        1'd1: begin
+        end
+        2'd2: begin
+            litedramcore_wishbone_dat_r <= litedramcore_dat_r;
+        end
+        default: begin
         end
     endcase
 end
@@ -9154,18 +9166,6 @@ always @(*) begin
             if ((litedramcore_wishbone_cyc & litedramcore_wishbone_stb)) begin
                 litedramcore_adr_wishbone2csr_next_value_ce1 <= 1'd1;
             end
-        end
-    endcase
-end
-always @(*) begin
-    litedramcore_wishbone_dat_r <= 32'd0;
-    case (litedramcore_wishbone2csr_state)
-        1'd1: begin
-        end
-        2'd2: begin
-            litedramcore_wishbone_dat_r <= litedramcore_dat_r;
-        end
-        default: begin
         end
     endcase
 end
@@ -9227,15 +9227,15 @@ always @(*) begin
 end
 assign csrbank0_init_error0_r = interface0_bank_bus_dat_w[0];
 always @(*) begin
-    csrbank0_init_error0_re <= 1'd0;
-    if ((csrbank0_sel & (interface0_bank_bus_adr[8:0] == 1'd1))) begin
-        csrbank0_init_error0_re <= interface0_bank_bus_we;
-    end
-end
-always @(*) begin
     csrbank0_init_error0_we <= 1'd0;
     if ((csrbank0_sel & (interface0_bank_bus_adr[8:0] == 1'd1))) begin
         csrbank0_init_error0_we <= (~interface0_bank_bus_we);
+    end
+end
+always @(*) begin
+    csrbank0_init_error0_re <= 1'd0;
+    if ((csrbank0_sel & (interface0_bank_bus_adr[8:0] == 1'd1))) begin
+        csrbank0_init_error0_re <= interface0_bank_bus_we;
     end
 end
 assign csrbank0_init_done0_w = init_done_storage;
@@ -9243,15 +9243,15 @@ assign csrbank0_init_error0_w = init_error_storage;
 assign csrbank1_sel = (interface1_bank_bus_adr[13:9] == 1'd1);
 assign csrbank1_dly_sel0_r = interface1_bank_bus_dat_w[1:0];
 always @(*) begin
-    csrbank1_dly_sel0_re <= 1'd0;
-    if ((csrbank1_sel & (interface1_bank_bus_adr[8:0] == 1'd0))) begin
-        csrbank1_dly_sel0_re <= interface1_bank_bus_we;
-    end
-end
-always @(*) begin
     csrbank1_dly_sel0_we <= 1'd0;
     if ((csrbank1_sel & (interface1_bank_bus_adr[8:0] == 1'd0))) begin
         csrbank1_dly_sel0_we <= (~interface1_bank_bus_we);
+    end
+end
+always @(*) begin
+    csrbank1_dly_sel0_re <= 1'd0;
+    if ((csrbank1_sel & (interface1_bank_bus_adr[8:0] == 1'd0))) begin
+        csrbank1_dly_sel0_re <= interface1_bank_bus_we;
     end
 end
 assign ddrphy_rdly_dq_rst_r = interface1_bank_bus_dat_w[0];
@@ -9351,15 +9351,15 @@ always @(*) begin
 end
 assign csrbank2_dfii_pi0_command0_r = interface2_bank_bus_dat_w[7:0];
 always @(*) begin
-    csrbank2_dfii_pi0_command0_re <= 1'd0;
-    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 1'd1))) begin
-        csrbank2_dfii_pi0_command0_re <= interface2_bank_bus_we;
-    end
-end
-always @(*) begin
     csrbank2_dfii_pi0_command0_we <= 1'd0;
     if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 1'd1))) begin
         csrbank2_dfii_pi0_command0_we <= (~interface2_bank_bus_we);
+    end
+end
+always @(*) begin
+    csrbank2_dfii_pi0_command0_re <= 1'd0;
+    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 1'd1))) begin
+        csrbank2_dfii_pi0_command0_re <= interface2_bank_bus_we;
     end
 end
 assign litedramcore_phaseinjector0_command_issue_r = interface2_bank_bus_dat_w[0];
@@ -9416,15 +9416,15 @@ always @(*) begin
 end
 assign csrbank2_dfii_pi0_wrdata0_r = interface2_bank_bus_dat_w[31:0];
 always @(*) begin
-    csrbank2_dfii_pi0_wrdata0_we <= 1'd0;
-    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 3'd6))) begin
-        csrbank2_dfii_pi0_wrdata0_we <= (~interface2_bank_bus_we);
-    end
-end
-always @(*) begin
     csrbank2_dfii_pi0_wrdata0_re <= 1'd0;
     if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 3'd6))) begin
         csrbank2_dfii_pi0_wrdata0_re <= interface2_bank_bus_we;
+    end
+end
+always @(*) begin
+    csrbank2_dfii_pi0_wrdata0_we <= 1'd0;
+    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 3'd6))) begin
+        csrbank2_dfii_pi0_wrdata0_we <= (~interface2_bank_bus_we);
     end
 end
 assign csrbank2_dfii_pi0_rddata1_r = interface2_bank_bus_dat_w[31:0];
@@ -9507,15 +9507,15 @@ always @(*) begin
 end
 assign csrbank2_dfii_pi1_wrdata1_r = interface2_bank_bus_dat_w[31:0];
 always @(*) begin
-    csrbank2_dfii_pi1_wrdata1_we <= 1'd0;
-    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 4'd13))) begin
-        csrbank2_dfii_pi1_wrdata1_we <= (~interface2_bank_bus_we);
-    end
-end
-always @(*) begin
     csrbank2_dfii_pi1_wrdata1_re <= 1'd0;
     if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 4'd13))) begin
         csrbank2_dfii_pi1_wrdata1_re <= interface2_bank_bus_we;
+    end
+end
+always @(*) begin
+    csrbank2_dfii_pi1_wrdata1_we <= 1'd0;
+    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 4'd13))) begin
+        csrbank2_dfii_pi1_wrdata1_we <= (~interface2_bank_bus_we);
     end
 end
 assign csrbank2_dfii_pi1_wrdata0_r = interface2_bank_bus_dat_w[31:0];
@@ -9546,15 +9546,15 @@ always @(*) begin
 end
 assign csrbank2_dfii_pi1_rddata0_r = interface2_bank_bus_dat_w[31:0];
 always @(*) begin
-    csrbank2_dfii_pi1_rddata0_we <= 1'd0;
-    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 5'd16))) begin
-        csrbank2_dfii_pi1_rddata0_we <= (~interface2_bank_bus_we);
-    end
-end
-always @(*) begin
     csrbank2_dfii_pi1_rddata0_re <= 1'd0;
     if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 5'd16))) begin
         csrbank2_dfii_pi1_rddata0_re <= interface2_bank_bus_we;
+    end
+end
+always @(*) begin
+    csrbank2_dfii_pi1_rddata0_we <= 1'd0;
+    if ((csrbank2_sel & (interface2_bank_bus_adr[8:0] == 5'd16))) begin
+        csrbank2_dfii_pi1_rddata0_we <= (~interface2_bank_bus_we);
     end
 end
 assign litedramcore_sel = litedramcore_storage[0];
@@ -9609,958 +9609,958 @@ assign interface1_bank_bus_dat_w = csr_interconnect_dat_w;
 assign interface2_bank_bus_dat_w = csr_interconnect_dat_w;
 assign csr_interconnect_dat_r = ((interface0_bank_bus_dat_r | interface1_bank_bus_dat_r) | interface2_bank_bus_dat_r);
 always @(*) begin
-    rhs_array_muxed0 <= 1'd0;
+    rhs_self0 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[0];
+            rhs_self0 <= litedramcore_choose_cmd_valids[0];
         end
         1'd1: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[1];
+            rhs_self0 <= litedramcore_choose_cmd_valids[1];
         end
         2'd2: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[2];
+            rhs_self0 <= litedramcore_choose_cmd_valids[2];
         end
         2'd3: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[3];
+            rhs_self0 <= litedramcore_choose_cmd_valids[3];
         end
         3'd4: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[4];
+            rhs_self0 <= litedramcore_choose_cmd_valids[4];
         end
         3'd5: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[5];
+            rhs_self0 <= litedramcore_choose_cmd_valids[5];
         end
         3'd6: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[6];
+            rhs_self0 <= litedramcore_choose_cmd_valids[6];
         end
         default: begin
-            rhs_array_muxed0 <= litedramcore_choose_cmd_valids[7];
+            rhs_self0 <= litedramcore_choose_cmd_valids[7];
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed1 <= 13'd0;
+    rhs_self1 <= 13'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine0_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine0_cmd_payload_a;
         end
         1'd1: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine1_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine1_cmd_payload_a;
         end
         2'd2: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine2_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine2_cmd_payload_a;
         end
         2'd3: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine3_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine3_cmd_payload_a;
         end
         3'd4: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine4_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine4_cmd_payload_a;
         end
         3'd5: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine5_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine5_cmd_payload_a;
         end
         3'd6: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine6_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine6_cmd_payload_a;
         end
         default: begin
-            rhs_array_muxed1 <= litedramcore_bankmachine7_cmd_payload_a;
+            rhs_self1 <= litedramcore_bankmachine7_cmd_payload_a;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed2 <= 3'd0;
+    rhs_self2 <= 3'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine0_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine0_cmd_payload_ba;
         end
         1'd1: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine1_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine1_cmd_payload_ba;
         end
         2'd2: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine2_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine2_cmd_payload_ba;
         end
         2'd3: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine3_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine3_cmd_payload_ba;
         end
         3'd4: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine4_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine4_cmd_payload_ba;
         end
         3'd5: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine5_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine5_cmd_payload_ba;
         end
         3'd6: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine6_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine6_cmd_payload_ba;
         end
         default: begin
-            rhs_array_muxed2 <= litedramcore_bankmachine7_cmd_payload_ba;
+            rhs_self2 <= litedramcore_bankmachine7_cmd_payload_ba;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed3 <= 1'd0;
+    rhs_self3 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine0_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine0_cmd_payload_is_read;
         end
         1'd1: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine1_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine1_cmd_payload_is_read;
         end
         2'd2: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine2_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine2_cmd_payload_is_read;
         end
         2'd3: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine3_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine3_cmd_payload_is_read;
         end
         3'd4: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine4_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine4_cmd_payload_is_read;
         end
         3'd5: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine5_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine5_cmd_payload_is_read;
         end
         3'd6: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine6_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine6_cmd_payload_is_read;
         end
         default: begin
-            rhs_array_muxed3 <= litedramcore_bankmachine7_cmd_payload_is_read;
+            rhs_self3 <= litedramcore_bankmachine7_cmd_payload_is_read;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed4 <= 1'd0;
+    rhs_self4 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine0_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine0_cmd_payload_is_write;
         end
         1'd1: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine1_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine1_cmd_payload_is_write;
         end
         2'd2: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine2_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine2_cmd_payload_is_write;
         end
         2'd3: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine3_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine3_cmd_payload_is_write;
         end
         3'd4: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine4_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine4_cmd_payload_is_write;
         end
         3'd5: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine5_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine5_cmd_payload_is_write;
         end
         3'd6: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine6_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine6_cmd_payload_is_write;
         end
         default: begin
-            rhs_array_muxed4 <= litedramcore_bankmachine7_cmd_payload_is_write;
+            rhs_self4 <= litedramcore_bankmachine7_cmd_payload_is_write;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed5 <= 1'd0;
+    rhs_self5 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine0_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine0_cmd_payload_is_cmd;
         end
         1'd1: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine1_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine1_cmd_payload_is_cmd;
         end
         2'd2: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine2_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine2_cmd_payload_is_cmd;
         end
         2'd3: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine3_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine3_cmd_payload_is_cmd;
         end
         3'd4: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine4_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine4_cmd_payload_is_cmd;
         end
         3'd5: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine5_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine5_cmd_payload_is_cmd;
         end
         3'd6: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine6_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine6_cmd_payload_is_cmd;
         end
         default: begin
-            rhs_array_muxed5 <= litedramcore_bankmachine7_cmd_payload_is_cmd;
+            rhs_self5 <= litedramcore_bankmachine7_cmd_payload_is_cmd;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed0 <= 1'd0;
+    t_self0 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            t_array_muxed0 <= litedramcore_bankmachine0_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine0_cmd_payload_cas;
         end
         1'd1: begin
-            t_array_muxed0 <= litedramcore_bankmachine1_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine1_cmd_payload_cas;
         end
         2'd2: begin
-            t_array_muxed0 <= litedramcore_bankmachine2_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine2_cmd_payload_cas;
         end
         2'd3: begin
-            t_array_muxed0 <= litedramcore_bankmachine3_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine3_cmd_payload_cas;
         end
         3'd4: begin
-            t_array_muxed0 <= litedramcore_bankmachine4_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine4_cmd_payload_cas;
         end
         3'd5: begin
-            t_array_muxed0 <= litedramcore_bankmachine5_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine5_cmd_payload_cas;
         end
         3'd6: begin
-            t_array_muxed0 <= litedramcore_bankmachine6_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine6_cmd_payload_cas;
         end
         default: begin
-            t_array_muxed0 <= litedramcore_bankmachine7_cmd_payload_cas;
+            t_self0 <= litedramcore_bankmachine7_cmd_payload_cas;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed1 <= 1'd0;
+    t_self1 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            t_array_muxed1 <= litedramcore_bankmachine0_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine0_cmd_payload_ras;
         end
         1'd1: begin
-            t_array_muxed1 <= litedramcore_bankmachine1_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine1_cmd_payload_ras;
         end
         2'd2: begin
-            t_array_muxed1 <= litedramcore_bankmachine2_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine2_cmd_payload_ras;
         end
         2'd3: begin
-            t_array_muxed1 <= litedramcore_bankmachine3_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine3_cmd_payload_ras;
         end
         3'd4: begin
-            t_array_muxed1 <= litedramcore_bankmachine4_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine4_cmd_payload_ras;
         end
         3'd5: begin
-            t_array_muxed1 <= litedramcore_bankmachine5_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine5_cmd_payload_ras;
         end
         3'd6: begin
-            t_array_muxed1 <= litedramcore_bankmachine6_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine6_cmd_payload_ras;
         end
         default: begin
-            t_array_muxed1 <= litedramcore_bankmachine7_cmd_payload_ras;
+            t_self1 <= litedramcore_bankmachine7_cmd_payload_ras;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed2 <= 1'd0;
+    t_self2 <= 1'd0;
     case (litedramcore_choose_cmd_grant)
         1'd0: begin
-            t_array_muxed2 <= litedramcore_bankmachine0_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine0_cmd_payload_we;
         end
         1'd1: begin
-            t_array_muxed2 <= litedramcore_bankmachine1_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine1_cmd_payload_we;
         end
         2'd2: begin
-            t_array_muxed2 <= litedramcore_bankmachine2_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine2_cmd_payload_we;
         end
         2'd3: begin
-            t_array_muxed2 <= litedramcore_bankmachine3_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine3_cmd_payload_we;
         end
         3'd4: begin
-            t_array_muxed2 <= litedramcore_bankmachine4_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine4_cmd_payload_we;
         end
         3'd5: begin
-            t_array_muxed2 <= litedramcore_bankmachine5_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine5_cmd_payload_we;
         end
         3'd6: begin
-            t_array_muxed2 <= litedramcore_bankmachine6_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine6_cmd_payload_we;
         end
         default: begin
-            t_array_muxed2 <= litedramcore_bankmachine7_cmd_payload_we;
+            t_self2 <= litedramcore_bankmachine7_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed6 <= 1'd0;
+    rhs_self6 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[0];
+            rhs_self6 <= litedramcore_choose_req_valids[0];
         end
         1'd1: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[1];
+            rhs_self6 <= litedramcore_choose_req_valids[1];
         end
         2'd2: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[2];
+            rhs_self6 <= litedramcore_choose_req_valids[2];
         end
         2'd3: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[3];
+            rhs_self6 <= litedramcore_choose_req_valids[3];
         end
         3'd4: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[4];
+            rhs_self6 <= litedramcore_choose_req_valids[4];
         end
         3'd5: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[5];
+            rhs_self6 <= litedramcore_choose_req_valids[5];
         end
         3'd6: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[6];
+            rhs_self6 <= litedramcore_choose_req_valids[6];
         end
         default: begin
-            rhs_array_muxed6 <= litedramcore_choose_req_valids[7];
+            rhs_self6 <= litedramcore_choose_req_valids[7];
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed7 <= 13'd0;
+    rhs_self7 <= 13'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine0_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine0_cmd_payload_a;
         end
         1'd1: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine1_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine1_cmd_payload_a;
         end
         2'd2: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine2_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine2_cmd_payload_a;
         end
         2'd3: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine3_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine3_cmd_payload_a;
         end
         3'd4: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine4_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine4_cmd_payload_a;
         end
         3'd5: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine5_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine5_cmd_payload_a;
         end
         3'd6: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine6_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine6_cmd_payload_a;
         end
         default: begin
-            rhs_array_muxed7 <= litedramcore_bankmachine7_cmd_payload_a;
+            rhs_self7 <= litedramcore_bankmachine7_cmd_payload_a;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed8 <= 3'd0;
+    rhs_self8 <= 3'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine0_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine0_cmd_payload_ba;
         end
         1'd1: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine1_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine1_cmd_payload_ba;
         end
         2'd2: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine2_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine2_cmd_payload_ba;
         end
         2'd3: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine3_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine3_cmd_payload_ba;
         end
         3'd4: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine4_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine4_cmd_payload_ba;
         end
         3'd5: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine5_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine5_cmd_payload_ba;
         end
         3'd6: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine6_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine6_cmd_payload_ba;
         end
         default: begin
-            rhs_array_muxed8 <= litedramcore_bankmachine7_cmd_payload_ba;
+            rhs_self8 <= litedramcore_bankmachine7_cmd_payload_ba;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed9 <= 1'd0;
+    rhs_self9 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine0_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine0_cmd_payload_is_read;
         end
         1'd1: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine1_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine1_cmd_payload_is_read;
         end
         2'd2: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine2_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine2_cmd_payload_is_read;
         end
         2'd3: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine3_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine3_cmd_payload_is_read;
         end
         3'd4: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine4_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine4_cmd_payload_is_read;
         end
         3'd5: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine5_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine5_cmd_payload_is_read;
         end
         3'd6: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine6_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine6_cmd_payload_is_read;
         end
         default: begin
-            rhs_array_muxed9 <= litedramcore_bankmachine7_cmd_payload_is_read;
+            rhs_self9 <= litedramcore_bankmachine7_cmd_payload_is_read;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed10 <= 1'd0;
+    rhs_self10 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine0_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine0_cmd_payload_is_write;
         end
         1'd1: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine1_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine1_cmd_payload_is_write;
         end
         2'd2: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine2_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine2_cmd_payload_is_write;
         end
         2'd3: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine3_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine3_cmd_payload_is_write;
         end
         3'd4: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine4_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine4_cmd_payload_is_write;
         end
         3'd5: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine5_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine5_cmd_payload_is_write;
         end
         3'd6: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine6_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine6_cmd_payload_is_write;
         end
         default: begin
-            rhs_array_muxed10 <= litedramcore_bankmachine7_cmd_payload_is_write;
+            rhs_self10 <= litedramcore_bankmachine7_cmd_payload_is_write;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed11 <= 1'd0;
+    rhs_self11 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine0_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine0_cmd_payload_is_cmd;
         end
         1'd1: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine1_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine1_cmd_payload_is_cmd;
         end
         2'd2: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine2_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine2_cmd_payload_is_cmd;
         end
         2'd3: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine3_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine3_cmd_payload_is_cmd;
         end
         3'd4: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine4_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine4_cmd_payload_is_cmd;
         end
         3'd5: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine5_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine5_cmd_payload_is_cmd;
         end
         3'd6: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine6_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine6_cmd_payload_is_cmd;
         end
         default: begin
-            rhs_array_muxed11 <= litedramcore_bankmachine7_cmd_payload_is_cmd;
+            rhs_self11 <= litedramcore_bankmachine7_cmd_payload_is_cmd;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed3 <= 1'd0;
+    t_self3 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            t_array_muxed3 <= litedramcore_bankmachine0_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine0_cmd_payload_cas;
         end
         1'd1: begin
-            t_array_muxed3 <= litedramcore_bankmachine1_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine1_cmd_payload_cas;
         end
         2'd2: begin
-            t_array_muxed3 <= litedramcore_bankmachine2_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine2_cmd_payload_cas;
         end
         2'd3: begin
-            t_array_muxed3 <= litedramcore_bankmachine3_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine3_cmd_payload_cas;
         end
         3'd4: begin
-            t_array_muxed3 <= litedramcore_bankmachine4_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine4_cmd_payload_cas;
         end
         3'd5: begin
-            t_array_muxed3 <= litedramcore_bankmachine5_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine5_cmd_payload_cas;
         end
         3'd6: begin
-            t_array_muxed3 <= litedramcore_bankmachine6_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine6_cmd_payload_cas;
         end
         default: begin
-            t_array_muxed3 <= litedramcore_bankmachine7_cmd_payload_cas;
+            t_self3 <= litedramcore_bankmachine7_cmd_payload_cas;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed4 <= 1'd0;
+    t_self4 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            t_array_muxed4 <= litedramcore_bankmachine0_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine0_cmd_payload_ras;
         end
         1'd1: begin
-            t_array_muxed4 <= litedramcore_bankmachine1_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine1_cmd_payload_ras;
         end
         2'd2: begin
-            t_array_muxed4 <= litedramcore_bankmachine2_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine2_cmd_payload_ras;
         end
         2'd3: begin
-            t_array_muxed4 <= litedramcore_bankmachine3_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine3_cmd_payload_ras;
         end
         3'd4: begin
-            t_array_muxed4 <= litedramcore_bankmachine4_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine4_cmd_payload_ras;
         end
         3'd5: begin
-            t_array_muxed4 <= litedramcore_bankmachine5_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine5_cmd_payload_ras;
         end
         3'd6: begin
-            t_array_muxed4 <= litedramcore_bankmachine6_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine6_cmd_payload_ras;
         end
         default: begin
-            t_array_muxed4 <= litedramcore_bankmachine7_cmd_payload_ras;
+            t_self4 <= litedramcore_bankmachine7_cmd_payload_ras;
         end
     endcase
 end
 always @(*) begin
-    t_array_muxed5 <= 1'd0;
+    t_self5 <= 1'd0;
     case (litedramcore_choose_req_grant)
         1'd0: begin
-            t_array_muxed5 <= litedramcore_bankmachine0_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine0_cmd_payload_we;
         end
         1'd1: begin
-            t_array_muxed5 <= litedramcore_bankmachine1_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine1_cmd_payload_we;
         end
         2'd2: begin
-            t_array_muxed5 <= litedramcore_bankmachine2_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine2_cmd_payload_we;
         end
         2'd3: begin
-            t_array_muxed5 <= litedramcore_bankmachine3_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine3_cmd_payload_we;
         end
         3'd4: begin
-            t_array_muxed5 <= litedramcore_bankmachine4_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine4_cmd_payload_we;
         end
         3'd5: begin
-            t_array_muxed5 <= litedramcore_bankmachine5_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine5_cmd_payload_we;
         end
         3'd6: begin
-            t_array_muxed5 <= litedramcore_bankmachine6_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine6_cmd_payload_we;
         end
         default: begin
-            t_array_muxed5 <= litedramcore_bankmachine7_cmd_payload_we;
+            t_self5 <= litedramcore_bankmachine7_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed12 <= 20'd0;
+    rhs_self12 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin0_grant)
         default: begin
-            rhs_array_muxed12 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self12 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed13 <= 1'd0;
+    rhs_self13 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin0_grant)
         default: begin
-            rhs_array_muxed13 <= port_cmd_payload_we;
+            rhs_self13 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed14 <= 1'd0;
+    rhs_self14 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin0_grant)
         default: begin
-            rhs_array_muxed14 <= (((port_cmd_payload_addr[9:7] == 1'd0) & (~(((((((litedramcore_litedramcore_locked0 | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self14 <= (((port_cmd_payload_addr[9:7] == 1'd0) & (~(((((((litedramcore_litedramcore_locked0 | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed15 <= 20'd0;
+    rhs_self15 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin1_grant)
         default: begin
-            rhs_array_muxed15 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self15 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed16 <= 1'd0;
+    rhs_self16 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin1_grant)
         default: begin
-            rhs_array_muxed16 <= port_cmd_payload_we;
+            rhs_self16 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed17 <= 1'd0;
+    rhs_self17 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin1_grant)
         default: begin
-            rhs_array_muxed17 <= (((port_cmd_payload_addr[9:7] == 1'd1) & (~(((((((litedramcore_litedramcore_locked1 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self17 <= (((port_cmd_payload_addr[9:7] == 1'd1) & (~(((((((litedramcore_litedramcore_locked1 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed18 <= 20'd0;
+    rhs_self18 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin2_grant)
         default: begin
-            rhs_array_muxed18 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self18 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed19 <= 1'd0;
+    rhs_self19 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin2_grant)
         default: begin
-            rhs_array_muxed19 <= port_cmd_payload_we;
+            rhs_self19 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed20 <= 1'd0;
+    rhs_self20 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin2_grant)
         default: begin
-            rhs_array_muxed20 <= (((port_cmd_payload_addr[9:7] == 2'd2) & (~(((((((litedramcore_litedramcore_locked2 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self20 <= (((port_cmd_payload_addr[9:7] == 2'd2) & (~(((((((litedramcore_litedramcore_locked2 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed21 <= 20'd0;
+    rhs_self21 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin3_grant)
         default: begin
-            rhs_array_muxed21 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self21 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed22 <= 1'd0;
+    rhs_self22 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin3_grant)
         default: begin
-            rhs_array_muxed22 <= port_cmd_payload_we;
+            rhs_self22 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed23 <= 1'd0;
+    rhs_self23 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin3_grant)
         default: begin
-            rhs_array_muxed23 <= (((port_cmd_payload_addr[9:7] == 2'd3) & (~(((((((litedramcore_litedramcore_locked3 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self23 <= (((port_cmd_payload_addr[9:7] == 2'd3) & (~(((((((litedramcore_litedramcore_locked3 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed24 <= 20'd0;
+    rhs_self24 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin4_grant)
         default: begin
-            rhs_array_muxed24 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self24 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed25 <= 1'd0;
+    rhs_self25 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin4_grant)
         default: begin
-            rhs_array_muxed25 <= port_cmd_payload_we;
+            rhs_self25 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed26 <= 1'd0;
+    rhs_self26 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin4_grant)
         default: begin
-            rhs_array_muxed26 <= (((port_cmd_payload_addr[9:7] == 3'd4) & (~(((((((litedramcore_litedramcore_locked4 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self26 <= (((port_cmd_payload_addr[9:7] == 3'd4) & (~(((((((litedramcore_litedramcore_locked4 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed27 <= 20'd0;
+    rhs_self27 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin5_grant)
         default: begin
-            rhs_array_muxed27 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self27 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed28 <= 1'd0;
+    rhs_self28 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin5_grant)
         default: begin
-            rhs_array_muxed28 <= port_cmd_payload_we;
+            rhs_self28 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed29 <= 1'd0;
+    rhs_self29 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin5_grant)
         default: begin
-            rhs_array_muxed29 <= (((port_cmd_payload_addr[9:7] == 3'd5) & (~(((((((litedramcore_litedramcore_locked5 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self29 <= (((port_cmd_payload_addr[9:7] == 3'd5) & (~(((((((litedramcore_litedramcore_locked5 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed30 <= 20'd0;
+    rhs_self30 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin6_grant)
         default: begin
-            rhs_array_muxed30 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self30 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed31 <= 1'd0;
+    rhs_self31 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin6_grant)
         default: begin
-            rhs_array_muxed31 <= port_cmd_payload_we;
+            rhs_self31 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed32 <= 1'd0;
+    rhs_self32 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin6_grant)
         default: begin
-            rhs_array_muxed32 <= (((port_cmd_payload_addr[9:7] == 3'd6) & (~(((((((litedramcore_litedramcore_locked6 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self32 <= (((port_cmd_payload_addr[9:7] == 3'd6) & (~(((((((litedramcore_litedramcore_locked6 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank7_lock & (litedramcore_litedramcore_roundrobin7_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed33 <= 20'd0;
+    rhs_self33 <= 20'd0;
     case (litedramcore_litedramcore_roundrobin7_grant)
         default: begin
-            rhs_array_muxed33 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
+            rhs_self33 <= {port_cmd_payload_addr[22:10], port_cmd_payload_addr[6:0]};
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed34 <= 1'd0;
+    rhs_self34 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin7_grant)
         default: begin
-            rhs_array_muxed34 <= port_cmd_payload_we;
+            rhs_self34 <= port_cmd_payload_we;
         end
     endcase
 end
 always @(*) begin
-    rhs_array_muxed35 <= 1'd0;
+    rhs_self35 <= 1'd0;
     case (litedramcore_litedramcore_roundrobin7_grant)
         default: begin
-            rhs_array_muxed35 <= (((port_cmd_payload_addr[9:7] == 3'd7) & (~(((((((litedramcore_litedramcore_locked7 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))))) & port_cmd_valid);
+            rhs_self35 <= (((port_cmd_payload_addr[9:7] == 3'd7) & (~(((((((litedramcore_litedramcore_locked7 | (litedramcore_interface_bank0_lock & (litedramcore_litedramcore_roundrobin0_grant == 1'd0))) | (litedramcore_interface_bank1_lock & (litedramcore_litedramcore_roundrobin1_grant == 1'd0))) | (litedramcore_interface_bank2_lock & (litedramcore_litedramcore_roundrobin2_grant == 1'd0))) | (litedramcore_interface_bank3_lock & (litedramcore_litedramcore_roundrobin3_grant == 1'd0))) | (litedramcore_interface_bank4_lock & (litedramcore_litedramcore_roundrobin4_grant == 1'd0))) | (litedramcore_interface_bank5_lock & (litedramcore_litedramcore_roundrobin5_grant == 1'd0))) | (litedramcore_interface_bank6_lock & (litedramcore_litedramcore_roundrobin6_grant == 1'd0))))) & port_cmd_valid);
         end
     endcase
 end
 always @(*) begin
-    array_muxed0 <= 3'd0;
-    case (litedramcore_steerer_sel0)
+    self0 <= 3'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed0 <= litedramcore_nop_ba[2:0];
+            self0 <= litedramcore_nop_ba[2:0];
         end
         1'd1: begin
-            array_muxed0 <= litedramcore_choose_cmd_cmd_payload_ba[2:0];
+            self0 <= litedramcore_choose_cmd_cmd_payload_ba[2:0];
         end
         2'd2: begin
-            array_muxed0 <= litedramcore_choose_req_cmd_payload_ba[2:0];
+            self0 <= litedramcore_choose_req_cmd_payload_ba[2:0];
         end
         default: begin
-            array_muxed0 <= litedramcore_cmd_payload_ba[2:0];
+            self0 <= litedramcore_cmd_payload_ba[2:0];
         end
     endcase
 end
 always @(*) begin
-    array_muxed1 <= 13'd0;
-    case (litedramcore_steerer_sel0)
+    self1 <= 13'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed1 <= litedramcore_nop_a;
+            self1 <= litedramcore_nop_a;
         end
         1'd1: begin
-            array_muxed1 <= litedramcore_choose_cmd_cmd_payload_a;
+            self1 <= litedramcore_choose_cmd_cmd_payload_a;
         end
         2'd2: begin
-            array_muxed1 <= litedramcore_choose_req_cmd_payload_a;
+            self1 <= litedramcore_choose_req_cmd_payload_a;
         end
         default: begin
-            array_muxed1 <= litedramcore_cmd_payload_a;
+            self1 <= litedramcore_cmd_payload_a;
         end
     endcase
 end
 always @(*) begin
-    array_muxed2 <= 1'd0;
-    case (litedramcore_steerer_sel0)
+    self2 <= 1'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed2 <= 1'd0;
+            self2 <= 1'd0;
         end
         1'd1: begin
-            array_muxed2 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_cas);
+            self2 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_cas);
         end
         2'd2: begin
-            array_muxed2 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_cas);
+            self2 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_cas);
         end
         default: begin
-            array_muxed2 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_cas);
+            self2 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_cas);
         end
     endcase
 end
 always @(*) begin
-    array_muxed3 <= 1'd0;
-    case (litedramcore_steerer_sel0)
+    self3 <= 1'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed3 <= 1'd0;
+            self3 <= 1'd0;
         end
         1'd1: begin
-            array_muxed3 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_ras);
+            self3 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_ras);
         end
         2'd2: begin
-            array_muxed3 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_ras);
+            self3 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_ras);
         end
         default: begin
-            array_muxed3 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_ras);
+            self3 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_ras);
         end
     endcase
 end
 always @(*) begin
-    array_muxed4 <= 1'd0;
-    case (litedramcore_steerer_sel0)
+    self4 <= 1'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed4 <= 1'd0;
+            self4 <= 1'd0;
         end
         1'd1: begin
-            array_muxed4 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_we);
+            self4 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_we);
         end
         2'd2: begin
-            array_muxed4 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_we);
+            self4 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_we);
         end
         default: begin
-            array_muxed4 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_we);
+            self4 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_we);
         end
     endcase
 end
 always @(*) begin
-    array_muxed5 <= 1'd0;
-    case (litedramcore_steerer_sel0)
+    self5 <= 1'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed5 <= 1'd0;
+            self5 <= 1'd0;
         end
         1'd1: begin
-            array_muxed5 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_read);
+            self5 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_read);
         end
         2'd2: begin
-            array_muxed5 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_read);
+            self5 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_read);
         end
         default: begin
-            array_muxed5 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_read);
+            self5 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_read);
         end
     endcase
 end
 always @(*) begin
-    array_muxed6 <= 1'd0;
-    case (litedramcore_steerer_sel0)
+    self6 <= 1'd0;
+    case (litedramcore_steerer0)
         1'd0: begin
-            array_muxed6 <= 1'd0;
+            self6 <= 1'd0;
         end
         1'd1: begin
-            array_muxed6 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_write);
+            self6 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_write);
         end
         2'd2: begin
-            array_muxed6 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_write);
+            self6 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_write);
         end
         default: begin
-            array_muxed6 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_write);
+            self6 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_write);
         end
     endcase
 end
 always @(*) begin
-    array_muxed7 <= 3'd0;
-    case (litedramcore_steerer_sel1)
+    self7 <= 3'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed7 <= litedramcore_nop_ba[2:0];
+            self7 <= litedramcore_nop_ba[2:0];
         end
         1'd1: begin
-            array_muxed7 <= litedramcore_choose_cmd_cmd_payload_ba[2:0];
+            self7 <= litedramcore_choose_cmd_cmd_payload_ba[2:0];
         end
         2'd2: begin
-            array_muxed7 <= litedramcore_choose_req_cmd_payload_ba[2:0];
+            self7 <= litedramcore_choose_req_cmd_payload_ba[2:0];
         end
         default: begin
-            array_muxed7 <= litedramcore_cmd_payload_ba[2:0];
+            self7 <= litedramcore_cmd_payload_ba[2:0];
         end
     endcase
 end
 always @(*) begin
-    array_muxed8 <= 13'd0;
-    case (litedramcore_steerer_sel1)
+    self8 <= 13'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed8 <= litedramcore_nop_a;
+            self8 <= litedramcore_nop_a;
         end
         1'd1: begin
-            array_muxed8 <= litedramcore_choose_cmd_cmd_payload_a;
+            self8 <= litedramcore_choose_cmd_cmd_payload_a;
         end
         2'd2: begin
-            array_muxed8 <= litedramcore_choose_req_cmd_payload_a;
+            self8 <= litedramcore_choose_req_cmd_payload_a;
         end
         default: begin
-            array_muxed8 <= litedramcore_cmd_payload_a;
+            self8 <= litedramcore_cmd_payload_a;
         end
     endcase
 end
 always @(*) begin
-    array_muxed9 <= 1'd0;
-    case (litedramcore_steerer_sel1)
+    self9 <= 1'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed9 <= 1'd0;
+            self9 <= 1'd0;
         end
         1'd1: begin
-            array_muxed9 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_cas);
+            self9 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_cas);
         end
         2'd2: begin
-            array_muxed9 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_cas);
+            self9 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_cas);
         end
         default: begin
-            array_muxed9 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_cas);
+            self9 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_cas);
         end
     endcase
 end
 always @(*) begin
-    array_muxed10 <= 1'd0;
-    case (litedramcore_steerer_sel1)
+    self10 <= 1'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed10 <= 1'd0;
+            self10 <= 1'd0;
         end
         1'd1: begin
-            array_muxed10 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_ras);
+            self10 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_ras);
         end
         2'd2: begin
-            array_muxed10 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_ras);
+            self10 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_ras);
         end
         default: begin
-            array_muxed10 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_ras);
+            self10 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_ras);
         end
     endcase
 end
 always @(*) begin
-    array_muxed11 <= 1'd0;
-    case (litedramcore_steerer_sel1)
+    self11 <= 1'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed11 <= 1'd0;
+            self11 <= 1'd0;
         end
         1'd1: begin
-            array_muxed11 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_we);
+            self11 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_we);
         end
         2'd2: begin
-            array_muxed11 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_we);
+            self11 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_we);
         end
         default: begin
-            array_muxed11 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_we);
+            self11 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_we);
         end
     endcase
 end
 always @(*) begin
-    array_muxed12 <= 1'd0;
-    case (litedramcore_steerer_sel1)
+    self12 <= 1'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed12 <= 1'd0;
+            self12 <= 1'd0;
         end
         1'd1: begin
-            array_muxed12 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_read);
+            self12 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_read);
         end
         2'd2: begin
-            array_muxed12 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_read);
+            self12 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_read);
         end
         default: begin
-            array_muxed12 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_read);
+            self12 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_read);
         end
     endcase
 end
 always @(*) begin
-    array_muxed13 <= 1'd0;
-    case (litedramcore_steerer_sel1)
+    self13 <= 1'd0;
+    case (litedramcore_steerer1)
         1'd0: begin
-            array_muxed13 <= 1'd0;
+            self13 <= 1'd0;
         end
         1'd1: begin
-            array_muxed13 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_write);
+            self13 <= ((litedramcore_choose_cmd_cmd_valid & litedramcore_choose_cmd_cmd_ready) & litedramcore_choose_cmd_cmd_payload_is_write);
         end
         2'd2: begin
-            array_muxed13 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_write);
+            self13 <= ((litedramcore_choose_req_cmd_valid & litedramcore_choose_req_cmd_ready) & litedramcore_choose_req_cmd_payload_is_write);
         end
         default: begin
-            array_muxed13 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_write);
+            self13 <= ((litedramcore_cmd_valid & litedramcore_cmd_ready) & litedramcore_cmd_payload_is_write);
         end
     endcase
 end
-assign ddrphy_lock1 = regs1;
+assign ddrphy_lock1 = multiregimpl1;
 
 
 //------------------------------------------------------------------------------
@@ -10569,44 +10569,44 @@ assign ddrphy_lock1 = regs1;
 
 always @(posedge init_clk) begin
     ddrphy_lock_d <= ddrphy_lock1;
-    if ((ddrphy_counter == 4'd8)) begin
+    if ((ddrphy_trigger == 4'd8)) begin
         ddrphy_freeze <= 1'd1;
     end
-    if ((ddrphy_counter == 5'd16)) begin
+    if ((ddrphy_trigger == 5'd16)) begin
         ddrphy_stop1 <= 1'd1;
     end
-    if ((ddrphy_counter == 5'd24)) begin
+    if ((ddrphy_trigger == 5'd24)) begin
         ddrphy_reset1 <= 1'd1;
     end
-    if ((ddrphy_counter == 6'd32)) begin
+    if ((ddrphy_trigger == 6'd32)) begin
         ddrphy_reset1 <= 1'd0;
     end
-    if ((ddrphy_counter == 6'd40)) begin
+    if ((ddrphy_trigger == 6'd40)) begin
         ddrphy_stop1 <= 1'd0;
     end
-    if ((ddrphy_counter == 6'd48)) begin
+    if ((ddrphy_trigger == 6'd48)) begin
         ddrphy_freeze <= 1'd0;
     end
-    if ((ddrphy_counter == 6'd56)) begin
+    if ((ddrphy_trigger == 6'd56)) begin
         ddrphy_pause1 <= 1'd1;
     end
-    if ((ddrphy_counter == 7'd64)) begin
+    if ((ddrphy_trigger == 7'd64)) begin
         ddrphy_update <= 1'd1;
     end
-    if ((ddrphy_counter == 7'd72)) begin
+    if ((ddrphy_trigger == 7'd72)) begin
         ddrphy_update <= 1'd0;
     end
-    if ((ddrphy_counter == 7'd80)) begin
+    if ((ddrphy_trigger == 7'd80)) begin
         ddrphy_pause1 <= 1'd0;
     end
-    if ((ddrphy_counter == 7'd80)) begin
-        ddrphy_counter <= 1'd0;
+    if ((ddrphy_trigger == 7'd80)) begin
+        ddrphy_trigger <= 1'd0;
     end else begin
-        if ((ddrphy_counter != 1'd0)) begin
-            ddrphy_counter <= (ddrphy_counter + 1'd1);
+        if ((ddrphy_trigger != 1'd0)) begin
+            ddrphy_trigger <= (ddrphy_trigger + 1'd1);
         end else begin
             if (ddrphy_new_lock) begin
-                ddrphy_counter <= 1'd1;
+                ddrphy_trigger <= 1'd1;
             end
         end
     end
@@ -10617,10 +10617,10 @@ always @(posedge init_clk) begin
         ddrphy_pause1 <= 1'd0;
         ddrphy_reset1 <= 1'd0;
         ddrphy_lock_d <= 1'd0;
-        ddrphy_counter <= 7'd0;
+        ddrphy_trigger <= 7'd0;
     end
-    regs0 <= ddrphy_lock0;
-    regs1 <= regs0;
+    multiregimpl0 <= ddrphy_lock0;
+    multiregimpl1 <= multiregimpl0;
 end
 
 always @(posedge por_clk) begin
@@ -11001,21 +11001,21 @@ always @(posedge sys_clk) begin
     litedramcore_cmd_payload_ras <= 1'd0;
     litedramcore_cmd_payload_we <= 1'd0;
     litedramcore_sequencer_done1 <= 1'd0;
-    if ((litedramcore_sequencer_start1 & (litedramcore_sequencer_counter == 1'd0))) begin
+    if ((litedramcore_sequencer_start1 & (litedramcore_sequencer_trigger == 1'd0))) begin
         litedramcore_cmd_payload_a <= 11'd1024;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd0;
         litedramcore_cmd_payload_ras <= 1'd1;
         litedramcore_cmd_payload_we <= 1'd1;
     end
-    if ((litedramcore_sequencer_counter == 2'd2)) begin
+    if ((litedramcore_sequencer_trigger == 2'd2)) begin
         litedramcore_cmd_payload_a <= 11'd1024;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd1;
         litedramcore_cmd_payload_ras <= 1'd1;
         litedramcore_cmd_payload_we <= 1'd0;
     end
-    if ((litedramcore_sequencer_counter == 7'd66)) begin
+    if ((litedramcore_sequencer_trigger == 7'd66)) begin
         litedramcore_cmd_payload_a <= 1'd0;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd0;
@@ -11023,14 +11023,14 @@ always @(posedge sys_clk) begin
         litedramcore_cmd_payload_we <= 1'd0;
         litedramcore_sequencer_done1 <= 1'd1;
     end
-    if ((litedramcore_sequencer_counter == 7'd66)) begin
-        litedramcore_sequencer_counter <= 1'd0;
+    if ((litedramcore_sequencer_trigger == 7'd66)) begin
+        litedramcore_sequencer_trigger <= 1'd0;
     end else begin
-        if ((litedramcore_sequencer_counter != 1'd0)) begin
-            litedramcore_sequencer_counter <= (litedramcore_sequencer_counter + 1'd1);
+        if ((litedramcore_sequencer_trigger != 1'd0)) begin
+            litedramcore_sequencer_trigger <= (litedramcore_sequencer_trigger + 1'd1);
         end else begin
             if (litedramcore_sequencer_start1) begin
-                litedramcore_sequencer_counter <= 1'd1;
+                litedramcore_sequencer_trigger <= 1'd1;
             end
         end
     end
@@ -11040,21 +11040,21 @@ always @(posedge sys_clk) begin
         litedramcore_zqcs_timer_count1 <= 26'd49999999;
     end
     litedramcore_zqcs_executer_done <= 1'd0;
-    if ((litedramcore_zqcs_executer_start & (litedramcore_zqcs_executer_counter == 1'd0))) begin
+    if ((litedramcore_zqcs_executer_start & (litedramcore_zqcs_executer_trigger == 1'd0))) begin
         litedramcore_cmd_payload_a <= 11'd1024;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd0;
         litedramcore_cmd_payload_ras <= 1'd1;
         litedramcore_cmd_payload_we <= 1'd1;
     end
-    if ((litedramcore_zqcs_executer_counter == 2'd2)) begin
+    if ((litedramcore_zqcs_executer_trigger == 2'd2)) begin
         litedramcore_cmd_payload_a <= 1'd0;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd0;
         litedramcore_cmd_payload_ras <= 1'd0;
         litedramcore_cmd_payload_we <= 1'd1;
     end
-    if ((litedramcore_zqcs_executer_counter == 6'd34)) begin
+    if ((litedramcore_zqcs_executer_trigger == 6'd34)) begin
         litedramcore_cmd_payload_a <= 1'd0;
         litedramcore_cmd_payload_ba <= 1'd0;
         litedramcore_cmd_payload_cas <= 1'd0;
@@ -11062,14 +11062,14 @@ always @(posedge sys_clk) begin
         litedramcore_cmd_payload_we <= 1'd0;
         litedramcore_zqcs_executer_done <= 1'd1;
     end
-    if ((litedramcore_zqcs_executer_counter == 6'd34)) begin
-        litedramcore_zqcs_executer_counter <= 1'd0;
+    if ((litedramcore_zqcs_executer_trigger == 6'd34)) begin
+        litedramcore_zqcs_executer_trigger <= 1'd0;
     end else begin
-        if ((litedramcore_zqcs_executer_counter != 1'd0)) begin
-            litedramcore_zqcs_executer_counter <= (litedramcore_zqcs_executer_counter + 1'd1);
+        if ((litedramcore_zqcs_executer_trigger != 1'd0)) begin
+            litedramcore_zqcs_executer_trigger <= (litedramcore_zqcs_executer_trigger + 1'd1);
         end else begin
             if (litedramcore_zqcs_executer_start) begin
-                litedramcore_zqcs_executer_counter <= 1'd1;
+                litedramcore_zqcs_executer_trigger <= 1'd1;
             end
         end
     end
@@ -12169,21 +12169,21 @@ always @(posedge sys_clk) begin
         endcase
     end
     litedramcore_dfi_p0_cs_n <= 1'd0;
-    litedramcore_dfi_p0_bank <= array_muxed0;
-    litedramcore_dfi_p0_address <= array_muxed1;
-    litedramcore_dfi_p0_cas_n <= (~array_muxed2);
-    litedramcore_dfi_p0_ras_n <= (~array_muxed3);
-    litedramcore_dfi_p0_we_n <= (~array_muxed4);
-    litedramcore_dfi_p0_rddata_en <= array_muxed5;
-    litedramcore_dfi_p0_wrdata_en <= array_muxed6;
+    litedramcore_dfi_p0_bank <= self0;
+    litedramcore_dfi_p0_address <= self1;
+    litedramcore_dfi_p0_cas_n <= (~self2);
+    litedramcore_dfi_p0_ras_n <= (~self3);
+    litedramcore_dfi_p0_we_n <= (~self4);
+    litedramcore_dfi_p0_rddata_en <= self5;
+    litedramcore_dfi_p0_wrdata_en <= self6;
     litedramcore_dfi_p1_cs_n <= 1'd0;
-    litedramcore_dfi_p1_bank <= array_muxed7;
-    litedramcore_dfi_p1_address <= array_muxed8;
-    litedramcore_dfi_p1_cas_n <= (~array_muxed9);
-    litedramcore_dfi_p1_ras_n <= (~array_muxed10);
-    litedramcore_dfi_p1_we_n <= (~array_muxed11);
-    litedramcore_dfi_p1_rddata_en <= array_muxed12;
-    litedramcore_dfi_p1_wrdata_en <= array_muxed13;
+    litedramcore_dfi_p1_bank <= self7;
+    litedramcore_dfi_p1_address <= self8;
+    litedramcore_dfi_p1_cas_n <= (~self9);
+    litedramcore_dfi_p1_ras_n <= (~self10);
+    litedramcore_dfi_p1_we_n <= (~self11);
+    litedramcore_dfi_p1_rddata_en <= self12;
+    litedramcore_dfi_p1_wrdata_en <= self13;
     if (litedramcore_trrdcon_valid) begin
         litedramcore_trrdcon_count <= 1'd1;
         if (1'd0) begin
@@ -12695,11 +12695,11 @@ always @(posedge sys_clk) begin
         litedramcore_postponer_req_o <= 1'd0;
         litedramcore_postponer_count <= 1'd0;
         litedramcore_sequencer_done1 <= 1'd0;
-        litedramcore_sequencer_counter <= 7'd0;
+        litedramcore_sequencer_trigger <= 7'd0;
         litedramcore_sequencer_count <= 1'd0;
         litedramcore_zqcs_timer_count1 <= 26'd49999999;
         litedramcore_zqcs_executer_done <= 1'd0;
-        litedramcore_zqcs_executer_counter <= 6'd0;
+        litedramcore_zqcs_executer_trigger <= 6'd0;
         litedramcore_bankmachine0_level <= 4'd0;
         litedramcore_bankmachine0_produce <= 3'd0;
         litedramcore_bankmachine0_consume <= 3'd0;
@@ -12893,1358 +12893,2145 @@ end
 // Specialized Logic
 //------------------------------------------------------------------------------
 
+//------------------------------------------------------------------------------
+// Instance ECLKBRIDGECS of ECLKBRIDGECS Module.
+//------------------------------------------------------------------------------
 ECLKBRIDGECS ECLKBRIDGECS(
-	.CLK0(sys2x_i_clk),
-	.SEL(1'd0),
-	.ECSOUT(crg_sys2x_clk_ecsout)
+	// Inputs.
+	.CLK0   (sys2x_i_clk),
+	.SEL    (1'd0),
+
+	// Outputs.
+	.ECSOUT (crg_sys2x_clk_ecsout)
 );
 
+//------------------------------------------------------------------------------
+// Instance ECLKSYNCB of ECLKSYNCB Module.
+//------------------------------------------------------------------------------
 ECLKSYNCB ECLKSYNCB(
-	.ECLKI(crg_sys2x_clk_ecsout),
-	.STOP(crg_stop),
-	.ECLKO(sys2x_clk)
+	// Inputs.
+	.ECLKI (crg_sys2x_clk_ecsout),
+	.STOP  (crg_stop),
+
+	// Outputs.
+	.ECLKO (sys2x_clk)
 );
 
+//------------------------------------------------------------------------------
+// Instance CLKDIVF of CLKDIVF Module.
+//------------------------------------------------------------------------------
 CLKDIVF #(
-	.DIV("2.0")
+	// Parameters.
+	.DIV ("2.0")
 ) CLKDIVF (
-	.ALIGNWD(1'd0),
-	.CLKI(sys2x_clk),
-	.RST(crg_reset0),
-	.CDIVX(sys_clk)
+	// Inputs.
+	.ALIGNWD (1'd0),
+	.CLKI    (sys2x_clk),
+	.RST     (crg_reset0),
+
+	// Outputs.
+	.CDIVX   (sys_clk)
 );
 
+//------------------------------------------------------------------------------
+// Instance DDRDLLA of DDRDLLA Module.
+//------------------------------------------------------------------------------
 DDRDLLA DDRDLLA(
-	.CLK(sys2x_clk),
-	.FREEZE(ddrphy_freeze),
-	.RST(init_rst),
-	.UDDCNTLN((~ddrphy_update)),
-	.DDRDEL(ddrphy_delay1),
-	.LOCK(ddrphy_lock0)
+	// Inputs.
+	.CLK      (sys2x_clk),
+	.FREEZE   (ddrphy_freeze),
+	.RST      (init_rst),
+	.UDDCNTLN ((~ddrphy_update)),
+
+	// Outputs.
+	.DDRDEL   (ddrphy_delay1),
+	.LOCK     (ddrphy_lock0)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F(
-	.D0(1'd0),
-	.D1(1'd1),
-	.D2(1'd0),
-	.D3(1'd1),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f0)
+	// Inputs.
+	.D0   (1'd0),
+	.D1   (1'd1),
+	.D2   (1'd0),
+	.D3   (1'd1),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f0)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG (
-	.A(ddrphy_pad_oddrx2f0),
-	.Z(ddram_clk_p)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f0),
+
+	// Outputs.
+	.Z (ddram_clk_p)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_1 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_1(
-	.D0(ddrphy_dfi_p0_reset_n),
-	.D1(ddrphy_dfi_p0_reset_n),
-	.D2(ddrphy_dfi_p1_reset_n),
-	.D3(ddrphy_dfi_p1_reset_n),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f1)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_reset_n),
+	.D1   (ddrphy_dfi_p0_reset_n),
+	.D2   (ddrphy_dfi_p1_reset_n),
+	.D3   (ddrphy_dfi_p1_reset_n),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f1)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_1 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_1 (
-	.A(ddrphy_pad_oddrx2f1),
-	.Z(ddram_reset_n)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f1),
+
+	// Outputs.
+	.Z (ddram_reset_n)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_2 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_2(
-	.D0(ddrphy_dfi_p0_cs_n),
-	.D1(ddrphy_dfi_p0_cs_n),
-	.D2(ddrphy_dfi_p1_cs_n),
-	.D3(ddrphy_dfi_p1_cs_n),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f2)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_cs_n),
+	.D1   (ddrphy_dfi_p0_cs_n),
+	.D2   (ddrphy_dfi_p1_cs_n),
+	.D3   (ddrphy_dfi_p1_cs_n),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f2)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_2 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_2 (
-	.A(ddrphy_pad_oddrx2f2),
-	.Z(ddram_cs_n)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f2),
+
+	// Outputs.
+	.Z (ddram_cs_n)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_3 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_3(
-	.D0(ddrphy_dfi_p0_address[0]),
-	.D1(ddrphy_dfi_p0_address[0]),
-	.D2(ddrphy_dfi_p1_address[0]),
-	.D3(ddrphy_dfi_p1_address[0]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f3)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[0]),
+	.D1   (ddrphy_dfi_p0_address[0]),
+	.D2   (ddrphy_dfi_p1_address[0]),
+	.D3   (ddrphy_dfi_p1_address[0]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f3)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_3 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_3 (
-	.A(ddrphy_pad_oddrx2f3),
-	.Z(ddram_a[0])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f3),
+
+	// Outputs.
+	.Z (ddram_a[0])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_4 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_4(
-	.D0(ddrphy_dfi_p0_address[1]),
-	.D1(ddrphy_dfi_p0_address[1]),
-	.D2(ddrphy_dfi_p1_address[1]),
-	.D3(ddrphy_dfi_p1_address[1]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f4)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[1]),
+	.D1   (ddrphy_dfi_p0_address[1]),
+	.D2   (ddrphy_dfi_p1_address[1]),
+	.D3   (ddrphy_dfi_p1_address[1]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f4)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_4 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_4 (
-	.A(ddrphy_pad_oddrx2f4),
-	.Z(ddram_a[1])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f4),
+
+	// Outputs.
+	.Z (ddram_a[1])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_5 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_5(
-	.D0(ddrphy_dfi_p0_address[2]),
-	.D1(ddrphy_dfi_p0_address[2]),
-	.D2(ddrphy_dfi_p1_address[2]),
-	.D3(ddrphy_dfi_p1_address[2]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f5)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[2]),
+	.D1   (ddrphy_dfi_p0_address[2]),
+	.D2   (ddrphy_dfi_p1_address[2]),
+	.D3   (ddrphy_dfi_p1_address[2]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f5)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_5 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_5 (
-	.A(ddrphy_pad_oddrx2f5),
-	.Z(ddram_a[2])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f5),
+
+	// Outputs.
+	.Z (ddram_a[2])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_6 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_6(
-	.D0(ddrphy_dfi_p0_address[3]),
-	.D1(ddrphy_dfi_p0_address[3]),
-	.D2(ddrphy_dfi_p1_address[3]),
-	.D3(ddrphy_dfi_p1_address[3]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f6)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[3]),
+	.D1   (ddrphy_dfi_p0_address[3]),
+	.D2   (ddrphy_dfi_p1_address[3]),
+	.D3   (ddrphy_dfi_p1_address[3]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f6)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_6 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_6 (
-	.A(ddrphy_pad_oddrx2f6),
-	.Z(ddram_a[3])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f6),
+
+	// Outputs.
+	.Z (ddram_a[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_7 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_7(
-	.D0(ddrphy_dfi_p0_address[4]),
-	.D1(ddrphy_dfi_p0_address[4]),
-	.D2(ddrphy_dfi_p1_address[4]),
-	.D3(ddrphy_dfi_p1_address[4]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f7)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[4]),
+	.D1   (ddrphy_dfi_p0_address[4]),
+	.D2   (ddrphy_dfi_p1_address[4]),
+	.D3   (ddrphy_dfi_p1_address[4]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f7)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_7 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_7 (
-	.A(ddrphy_pad_oddrx2f7),
-	.Z(ddram_a[4])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f7),
+
+	// Outputs.
+	.Z (ddram_a[4])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_8 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_8(
-	.D0(ddrphy_dfi_p0_address[5]),
-	.D1(ddrphy_dfi_p0_address[5]),
-	.D2(ddrphy_dfi_p1_address[5]),
-	.D3(ddrphy_dfi_p1_address[5]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f8)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[5]),
+	.D1   (ddrphy_dfi_p0_address[5]),
+	.D2   (ddrphy_dfi_p1_address[5]),
+	.D3   (ddrphy_dfi_p1_address[5]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f8)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_8 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_8 (
-	.A(ddrphy_pad_oddrx2f8),
-	.Z(ddram_a[5])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f8),
+
+	// Outputs.
+	.Z (ddram_a[5])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_9 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_9(
-	.D0(ddrphy_dfi_p0_address[6]),
-	.D1(ddrphy_dfi_p0_address[6]),
-	.D2(ddrphy_dfi_p1_address[6]),
-	.D3(ddrphy_dfi_p1_address[6]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f9)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[6]),
+	.D1   (ddrphy_dfi_p0_address[6]),
+	.D2   (ddrphy_dfi_p1_address[6]),
+	.D3   (ddrphy_dfi_p1_address[6]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f9)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_9 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_9 (
-	.A(ddrphy_pad_oddrx2f9),
-	.Z(ddram_a[6])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f9),
+
+	// Outputs.
+	.Z (ddram_a[6])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_10 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_10(
-	.D0(ddrphy_dfi_p0_address[7]),
-	.D1(ddrphy_dfi_p0_address[7]),
-	.D2(ddrphy_dfi_p1_address[7]),
-	.D3(ddrphy_dfi_p1_address[7]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f10)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[7]),
+	.D1   (ddrphy_dfi_p0_address[7]),
+	.D2   (ddrphy_dfi_p1_address[7]),
+	.D3   (ddrphy_dfi_p1_address[7]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f10)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_10 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_10 (
-	.A(ddrphy_pad_oddrx2f10),
-	.Z(ddram_a[7])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f10),
+
+	// Outputs.
+	.Z (ddram_a[7])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_11 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_11(
-	.D0(ddrphy_dfi_p0_address[8]),
-	.D1(ddrphy_dfi_p0_address[8]),
-	.D2(ddrphy_dfi_p1_address[8]),
-	.D3(ddrphy_dfi_p1_address[8]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f11)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[8]),
+	.D1   (ddrphy_dfi_p0_address[8]),
+	.D2   (ddrphy_dfi_p1_address[8]),
+	.D3   (ddrphy_dfi_p1_address[8]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f11)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_11 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_11 (
-	.A(ddrphy_pad_oddrx2f11),
-	.Z(ddram_a[8])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f11),
+
+	// Outputs.
+	.Z (ddram_a[8])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_12 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_12(
-	.D0(ddrphy_dfi_p0_address[9]),
-	.D1(ddrphy_dfi_p0_address[9]),
-	.D2(ddrphy_dfi_p1_address[9]),
-	.D3(ddrphy_dfi_p1_address[9]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f12)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[9]),
+	.D1   (ddrphy_dfi_p0_address[9]),
+	.D2   (ddrphy_dfi_p1_address[9]),
+	.D3   (ddrphy_dfi_p1_address[9]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f12)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_12 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_12 (
-	.A(ddrphy_pad_oddrx2f12),
-	.Z(ddram_a[9])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f12),
+
+	// Outputs.
+	.Z (ddram_a[9])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_13 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_13(
-	.D0(ddrphy_dfi_p0_address[10]),
-	.D1(ddrphy_dfi_p0_address[10]),
-	.D2(ddrphy_dfi_p1_address[10]),
-	.D3(ddrphy_dfi_p1_address[10]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f13)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[10]),
+	.D1   (ddrphy_dfi_p0_address[10]),
+	.D2   (ddrphy_dfi_p1_address[10]),
+	.D3   (ddrphy_dfi_p1_address[10]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f13)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_13 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_13 (
-	.A(ddrphy_pad_oddrx2f13),
-	.Z(ddram_a[10])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f13),
+
+	// Outputs.
+	.Z (ddram_a[10])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_14 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_14(
-	.D0(ddrphy_dfi_p0_address[11]),
-	.D1(ddrphy_dfi_p0_address[11]),
-	.D2(ddrphy_dfi_p1_address[11]),
-	.D3(ddrphy_dfi_p1_address[11]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f14)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[11]),
+	.D1   (ddrphy_dfi_p0_address[11]),
+	.D2   (ddrphy_dfi_p1_address[11]),
+	.D3   (ddrphy_dfi_p1_address[11]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f14)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_14 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_14 (
-	.A(ddrphy_pad_oddrx2f14),
-	.Z(ddram_a[11])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f14),
+
+	// Outputs.
+	.Z (ddram_a[11])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_15 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_15(
-	.D0(ddrphy_dfi_p0_address[12]),
-	.D1(ddrphy_dfi_p0_address[12]),
-	.D2(ddrphy_dfi_p1_address[12]),
-	.D3(ddrphy_dfi_p1_address[12]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f15)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_address[12]),
+	.D1   (ddrphy_dfi_p0_address[12]),
+	.D2   (ddrphy_dfi_p1_address[12]),
+	.D3   (ddrphy_dfi_p1_address[12]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f15)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_15 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_15 (
-	.A(ddrphy_pad_oddrx2f15),
-	.Z(ddram_a[12])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f15),
+
+	// Outputs.
+	.Z (ddram_a[12])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_16 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_16(
-	.D0(ddrphy_dfi_p0_bank[0]),
-	.D1(ddrphy_dfi_p0_bank[0]),
-	.D2(ddrphy_dfi_p1_bank[0]),
-	.D3(ddrphy_dfi_p1_bank[0]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f16)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_bank[0]),
+	.D1   (ddrphy_dfi_p0_bank[0]),
+	.D2   (ddrphy_dfi_p1_bank[0]),
+	.D3   (ddrphy_dfi_p1_bank[0]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f16)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_16 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_16 (
-	.A(ddrphy_pad_oddrx2f16),
-	.Z(ddram_ba[0])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f16),
+
+	// Outputs.
+	.Z (ddram_ba[0])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_17 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_17(
-	.D0(ddrphy_dfi_p0_bank[1]),
-	.D1(ddrphy_dfi_p0_bank[1]),
-	.D2(ddrphy_dfi_p1_bank[1]),
-	.D3(ddrphy_dfi_p1_bank[1]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f17)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_bank[1]),
+	.D1   (ddrphy_dfi_p0_bank[1]),
+	.D2   (ddrphy_dfi_p1_bank[1]),
+	.D3   (ddrphy_dfi_p1_bank[1]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f17)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_17 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_17 (
-	.A(ddrphy_pad_oddrx2f17),
-	.Z(ddram_ba[1])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f17),
+
+	// Outputs.
+	.Z (ddram_ba[1])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_18 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_18(
-	.D0(ddrphy_dfi_p0_bank[2]),
-	.D1(ddrphy_dfi_p0_bank[2]),
-	.D2(ddrphy_dfi_p1_bank[2]),
-	.D3(ddrphy_dfi_p1_bank[2]),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f18)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_bank[2]),
+	.D1   (ddrphy_dfi_p0_bank[2]),
+	.D2   (ddrphy_dfi_p1_bank[2]),
+	.D3   (ddrphy_dfi_p1_bank[2]),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f18)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_18 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_18 (
-	.A(ddrphy_pad_oddrx2f18),
-	.Z(ddram_ba[2])
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f18),
+
+	// Outputs.
+	.Z (ddram_ba[2])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_19 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_19(
-	.D0(ddrphy_dfi_p0_ras_n),
-	.D1(ddrphy_dfi_p0_ras_n),
-	.D2(ddrphy_dfi_p1_ras_n),
-	.D3(ddrphy_dfi_p1_ras_n),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f19)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_ras_n),
+	.D1   (ddrphy_dfi_p0_ras_n),
+	.D2   (ddrphy_dfi_p1_ras_n),
+	.D3   (ddrphy_dfi_p1_ras_n),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f19)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_19 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_19 (
-	.A(ddrphy_pad_oddrx2f19),
-	.Z(ddram_ras_n)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f19),
+
+	// Outputs.
+	.Z (ddram_ras_n)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_20 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_20(
-	.D0(ddrphy_dfi_p0_cas_n),
-	.D1(ddrphy_dfi_p0_cas_n),
-	.D2(ddrphy_dfi_p1_cas_n),
-	.D3(ddrphy_dfi_p1_cas_n),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f20)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_cas_n),
+	.D1   (ddrphy_dfi_p0_cas_n),
+	.D2   (ddrphy_dfi_p1_cas_n),
+	.D3   (ddrphy_dfi_p1_cas_n),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f20)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_20 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_20 (
-	.A(ddrphy_pad_oddrx2f20),
-	.Z(ddram_cas_n)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f20),
+
+	// Outputs.
+	.Z (ddram_cas_n)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_21 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_21(
-	.D0(ddrphy_dfi_p0_we_n),
-	.D1(ddrphy_dfi_p0_we_n),
-	.D2(ddrphy_dfi_p1_we_n),
-	.D3(ddrphy_dfi_p1_we_n),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f21)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_we_n),
+	.D1   (ddrphy_dfi_p0_we_n),
+	.D2   (ddrphy_dfi_p1_we_n),
+	.D3   (ddrphy_dfi_p1_we_n),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f21)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_21 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_21 (
-	.A(ddrphy_pad_oddrx2f21),
-	.Z(ddram_we_n)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f21),
+
+	// Outputs.
+	.Z (ddram_we_n)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_22 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_22(
-	.D0(ddrphy_dfi_p0_cke),
-	.D1(ddrphy_dfi_p0_cke),
-	.D2(ddrphy_dfi_p1_cke),
-	.D3(ddrphy_dfi_p1_cke),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f22)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_cke),
+	.D1   (ddrphy_dfi_p0_cke),
+	.D2   (ddrphy_dfi_p1_cke),
+	.D3   (ddrphy_dfi_p1_cke),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f22)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_22 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_22 (
-	.A(ddrphy_pad_oddrx2f22),
-	.Z(ddram_cke)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f22),
+
+	// Outputs.
+	.Z (ddram_cke)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2F_23 of ODDRX2F Module.
+//------------------------------------------------------------------------------
 ODDRX2F ODDRX2F_23(
-	.D0(ddrphy_dfi_p0_odt),
-	.D1(ddrphy_dfi_p0_odt),
-	.D2(ddrphy_dfi_p1_odt),
-	.D3(ddrphy_dfi_p1_odt),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_pad_oddrx2f23)
+	// Inputs.
+	.D0   (ddrphy_dfi_p0_odt),
+	.D1   (ddrphy_dfi_p0_odt),
+	.D2   (ddrphy_dfi_p1_odt),
+	.D3   (ddrphy_dfi_p1_odt),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_pad_oddrx2f23)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_23 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_VALUE(1'd0)
+	// Parameters.
+	.DEL_VALUE (1'd0)
 ) DELAYG_23 (
-	.A(ddrphy_pad_oddrx2f23),
-	.Z(ddram_odt)
+	// Inputs.
+	.A (ddrphy_pad_oddrx2f23),
+
+	// Outputs.
+	.Z (ddram_odt)
 );
 
+//------------------------------------------------------------------------------
+// Instance DQSBUFM of DQSBUFM Module.
+//------------------------------------------------------------------------------
 DQSBUFM #(
-	.DQS_LI_DEL_ADJ("MINUS"),
-	.DQS_LI_DEL_VAL(1'd1),
-	.DQS_LO_DEL_ADJ("MINUS"),
-	.DQS_LO_DEL_VAL(3'd4)
+	// Parameters.
+	.DQS_LI_DEL_ADJ ("MINUS"),
+	.DQS_LI_DEL_VAL (1'd1),
+	.DQS_LO_DEL_ADJ ("MINUS"),
+	.DQS_LO_DEL_VAL (3'd4)
 ) DQSBUFM (
-	.DDRDEL(ddrphy_delay0),
-	.DQSI(ddrphy_dqs_i0),
-	.ECLK(sys2x_clk),
-	.PAUSE((ddrphy_pause0 | ddrphy_dly_sel_storage[0])),
-	.RDDIRECTION(1'd1),
-	.RDLOADN(1'd0),
-	.RDMOVE(1'd0),
-	.READ0(ddrphy_dqs_re),
-	.READ1(ddrphy_dqs_re),
-	.READCLKSEL0(ddrphy_rdly0[0]),
-	.READCLKSEL1(ddrphy_rdly0[1]),
-	.READCLKSEL2(ddrphy_rdly0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRDIRECTION(1'd1),
-	.WRLOADN(1'd0),
-	.WRMOVE(1'd0),
-	.BURSTDET(ddrphy_burstdet0),
-	.DATAVALID(ddrphy_datavalid[0]),
-	.DQSR90(ddrphy_dqsr900),
-	.DQSW(ddrphy_dqsw0),
-	.DQSW270(ddrphy_dqsw2700),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2])
+	// Inputs.
+	.DDRDEL      (ddrphy_delay0),
+	.DQSI        (ddrphy_dqs_i0),
+	.ECLK        (sys2x_clk),
+	.PAUSE       ((ddrphy_pause0 | ddrphy_dly_sel_storage[0])),
+	.RDDIRECTION (1'd1),
+	.RDLOADN     (1'd0),
+	.RDMOVE      (1'd0),
+	.READ0       (ddrphy_dqs_re),
+	.READ1       (ddrphy_dqs_re),
+	.READCLKSEL0 (ddrphy_rdly0[0]),
+	.READCLKSEL1 (ddrphy_rdly0[1]),
+	.READCLKSEL2 (ddrphy_rdly0[2]),
+	.RST         (sys_rst),
+	.SCLK        (sys_clk),
+	.WRDIRECTION (1'd1),
+	.WRLOADN     (1'd0),
+	.WRMOVE      (1'd0),
+
+	// Outputs.
+	.BURSTDET    (ddrphy_burstdet0),
+	.DATAVALID   (ddrphy_datavalid[0]),
+	.DQSR90      (ddrphy_dqsr900),
+	.DQSW        (ddrphy_dqsw0),
+	.DQSW270     (ddrphy_dqsw2700),
+	.RDPNTR0     (ddrphy_rdpntr0[0]),
+	.RDPNTR1     (ddrphy_rdpntr0[1]),
+	.RDPNTR2     (ddrphy_rdpntr0[2]),
+	.WRPNTR0     (ddrphy_wrpntr0[0]),
+	.WRPNTR1     (ddrphy_wrpntr0[1]),
+	.WRPNTR2     (ddrphy_wrpntr0[2])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQSB of ODDRX2DQSB Module.
+//------------------------------------------------------------------------------
 ODDRX2DQSB ODDRX2DQSB(
-	.D0(1'd0),
-	.D1(1'd1),
-	.D2(1'd0),
-	.D3(1'd1),
-	.DQSW(ddrphy_dqsw0),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dqs0)
+	// Inputs.
+	.D0   (1'd0),
+	.D1   (1'd1),
+	.D2   (1'd0),
+	.D3   (1'd1),
+	.DQSW (ddrphy_dqsw0),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_dqs0)
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQSA of TSHX2DQSA Module.
+//------------------------------------------------------------------------------
 TSHX2DQSA TSHX2DQSA(
-	.DQSW(ddrphy_dqsw0),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~(ddrphy_dqs_oe | ddrphy_dqs_postamble))),
-	.T1((~(ddrphy_dqs_oe | ddrphy_dqs_preamble))),
-	.Q(ddrphy_dqs_oe_n0)
+	// Inputs.
+	.DQSW (ddrphy_dqsw0),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+	.T0   ((~(ddrphy_dqs_oe | ddrphy_dqs_postamble))),
+	.T1   ((~(ddrphy_dqs_oe | ddrphy_dqs_preamble))),
+
+	// Outputs.
+	.Q    (ddrphy_dqs_oe_n0)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA(
-	.D0(ddrphy_dm_o_data_muxed0[0]),
-	.D1(ddrphy_dm_o_data_muxed0[1]),
-	.D2(ddrphy_dm_o_data_muxed0[2]),
-	.D3(ddrphy_dm_o_data_muxed0[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddram_dm[0])
+	// Inputs.
+	.D0      (ddrphy_dm_o_data_muxed0[0]),
+	.D1      (ddrphy_dm_o_data_muxed0[1]),
+	.D2      (ddrphy_dm_o_data_muxed0[2]),
+	.D3      (ddrphy_dm_o_data_muxed0[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddram_dm[0])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_1 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_1(
-	.D0(ddrphy_dq_o_data_muxed0[0]),
-	.D1(ddrphy_dq_o_data_muxed0[1]),
-	.D2(ddrphy_dq_o_data_muxed0[2]),
-	.D3(ddrphy_dq_o_data_muxed0[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o0)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed0[0]),
+	.D1      (ddrphy_dq_o_data_muxed0[1]),
+	.D2      (ddrphy_dq_o_data_muxed0[2]),
+	.D3      (ddrphy_dq_o_data_muxed0[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o0)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_24 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_24 (
-	.A(ddrphy_dq_i0),
-	.Z(ddrphy_dq_i_delayed0)
+	// Inputs.
+	.A (ddrphy_dq_i0),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed0)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA(
-	.D(ddrphy_dq_i_delayed0),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip0_i[0]),
-	.Q1(ddrphy_bitslip0_i[1]),
-	.Q2(ddrphy_bitslip0_i[2]),
-	.Q3(ddrphy_bitslip0_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed0),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip0_i[0]),
+	.Q1      (ddrphy_bitslip0_i[1]),
+	.Q2      (ddrphy_bitslip0_i[2]),
+	.Q3      (ddrphy_bitslip0_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n0)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n0)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_2 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_2(
-	.D0(ddrphy_dq_o_data_muxed1[0]),
-	.D1(ddrphy_dq_o_data_muxed1[1]),
-	.D2(ddrphy_dq_o_data_muxed1[2]),
-	.D3(ddrphy_dq_o_data_muxed1[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o1)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed1[0]),
+	.D1      (ddrphy_dq_o_data_muxed1[1]),
+	.D2      (ddrphy_dq_o_data_muxed1[2]),
+	.D3      (ddrphy_dq_o_data_muxed1[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o1)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_25 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_25 (
-	.A(ddrphy_dq_i1),
-	.Z(ddrphy_dq_i_delayed1)
+	// Inputs.
+	.A (ddrphy_dq_i1),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed1)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_1 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_1(
-	.D(ddrphy_dq_i_delayed1),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip1_i[0]),
-	.Q1(ddrphy_bitslip1_i[1]),
-	.Q2(ddrphy_bitslip1_i[2]),
-	.Q3(ddrphy_bitslip1_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed1),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip1_i[0]),
+	.Q1      (ddrphy_bitslip1_i[1]),
+	.Q2      (ddrphy_bitslip1_i[2]),
+	.Q3      (ddrphy_bitslip1_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_1 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_1(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n1)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n1)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_3 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_3(
-	.D0(ddrphy_dq_o_data_muxed2[0]),
-	.D1(ddrphy_dq_o_data_muxed2[1]),
-	.D2(ddrphy_dq_o_data_muxed2[2]),
-	.D3(ddrphy_dq_o_data_muxed2[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o2)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed2[0]),
+	.D1      (ddrphy_dq_o_data_muxed2[1]),
+	.D2      (ddrphy_dq_o_data_muxed2[2]),
+	.D3      (ddrphy_dq_o_data_muxed2[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o2)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_26 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_26 (
-	.A(ddrphy_dq_i2),
-	.Z(ddrphy_dq_i_delayed2)
+	// Inputs.
+	.A (ddrphy_dq_i2),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed2)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_2 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_2(
-	.D(ddrphy_dq_i_delayed2),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip2_i[0]),
-	.Q1(ddrphy_bitslip2_i[1]),
-	.Q2(ddrphy_bitslip2_i[2]),
-	.Q3(ddrphy_bitslip2_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed2),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip2_i[0]),
+	.Q1      (ddrphy_bitslip2_i[1]),
+	.Q2      (ddrphy_bitslip2_i[2]),
+	.Q3      (ddrphy_bitslip2_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_2 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_2(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n2)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n2)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_4 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_4(
-	.D0(ddrphy_dq_o_data_muxed3[0]),
-	.D1(ddrphy_dq_o_data_muxed3[1]),
-	.D2(ddrphy_dq_o_data_muxed3[2]),
-	.D3(ddrphy_dq_o_data_muxed3[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o3)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed3[0]),
+	.D1      (ddrphy_dq_o_data_muxed3[1]),
+	.D2      (ddrphy_dq_o_data_muxed3[2]),
+	.D3      (ddrphy_dq_o_data_muxed3[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o3)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_27 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_27 (
-	.A(ddrphy_dq_i3),
-	.Z(ddrphy_dq_i_delayed3)
+	// Inputs.
+	.A (ddrphy_dq_i3),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed3)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_3 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_3(
-	.D(ddrphy_dq_i_delayed3),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip3_i[0]),
-	.Q1(ddrphy_bitslip3_i[1]),
-	.Q2(ddrphy_bitslip3_i[2]),
-	.Q3(ddrphy_bitslip3_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed3),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip3_i[0]),
+	.Q1      (ddrphy_bitslip3_i[1]),
+	.Q2      (ddrphy_bitslip3_i[2]),
+	.Q3      (ddrphy_bitslip3_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_3 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_3(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n3)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n3)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_5 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_5(
-	.D0(ddrphy_dq_o_data_muxed4[0]),
-	.D1(ddrphy_dq_o_data_muxed4[1]),
-	.D2(ddrphy_dq_o_data_muxed4[2]),
-	.D3(ddrphy_dq_o_data_muxed4[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o4)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed4[0]),
+	.D1      (ddrphy_dq_o_data_muxed4[1]),
+	.D2      (ddrphy_dq_o_data_muxed4[2]),
+	.D3      (ddrphy_dq_o_data_muxed4[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o4)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_28 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_28 (
-	.A(ddrphy_dq_i4),
-	.Z(ddrphy_dq_i_delayed4)
+	// Inputs.
+	.A (ddrphy_dq_i4),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed4)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_4 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_4(
-	.D(ddrphy_dq_i_delayed4),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip4_i[0]),
-	.Q1(ddrphy_bitslip4_i[1]),
-	.Q2(ddrphy_bitslip4_i[2]),
-	.Q3(ddrphy_bitslip4_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed4),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip4_i[0]),
+	.Q1      (ddrphy_bitslip4_i[1]),
+	.Q2      (ddrphy_bitslip4_i[2]),
+	.Q3      (ddrphy_bitslip4_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_4 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_4(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n4)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n4)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_6 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_6(
-	.D0(ddrphy_dq_o_data_muxed5[0]),
-	.D1(ddrphy_dq_o_data_muxed5[1]),
-	.D2(ddrphy_dq_o_data_muxed5[2]),
-	.D3(ddrphy_dq_o_data_muxed5[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o5)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed5[0]),
+	.D1      (ddrphy_dq_o_data_muxed5[1]),
+	.D2      (ddrphy_dq_o_data_muxed5[2]),
+	.D3      (ddrphy_dq_o_data_muxed5[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o5)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_29 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_29 (
-	.A(ddrphy_dq_i5),
-	.Z(ddrphy_dq_i_delayed5)
+	// Inputs.
+	.A (ddrphy_dq_i5),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed5)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_5 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_5(
-	.D(ddrphy_dq_i_delayed5),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip5_i[0]),
-	.Q1(ddrphy_bitslip5_i[1]),
-	.Q2(ddrphy_bitslip5_i[2]),
-	.Q3(ddrphy_bitslip5_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed5),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip5_i[0]),
+	.Q1      (ddrphy_bitslip5_i[1]),
+	.Q2      (ddrphy_bitslip5_i[2]),
+	.Q3      (ddrphy_bitslip5_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_5 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_5(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n5)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n5)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_7 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_7(
-	.D0(ddrphy_dq_o_data_muxed6[0]),
-	.D1(ddrphy_dq_o_data_muxed6[1]),
-	.D2(ddrphy_dq_o_data_muxed6[2]),
-	.D3(ddrphy_dq_o_data_muxed6[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o6)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed6[0]),
+	.D1      (ddrphy_dq_o_data_muxed6[1]),
+	.D2      (ddrphy_dq_o_data_muxed6[2]),
+	.D3      (ddrphy_dq_o_data_muxed6[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o6)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_30 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_30 (
-	.A(ddrphy_dq_i6),
-	.Z(ddrphy_dq_i_delayed6)
+	// Inputs.
+	.A (ddrphy_dq_i6),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed6)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_6 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_6(
-	.D(ddrphy_dq_i_delayed6),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip6_i[0]),
-	.Q1(ddrphy_bitslip6_i[1]),
-	.Q2(ddrphy_bitslip6_i[2]),
-	.Q3(ddrphy_bitslip6_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed6),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip6_i[0]),
+	.Q1      (ddrphy_bitslip6_i[1]),
+	.Q2      (ddrphy_bitslip6_i[2]),
+	.Q3      (ddrphy_bitslip6_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_6 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_6(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n6)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n6)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_8 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_8(
-	.D0(ddrphy_dq_o_data_muxed7[0]),
-	.D1(ddrphy_dq_o_data_muxed7[1]),
-	.D2(ddrphy_dq_o_data_muxed7[2]),
-	.D3(ddrphy_dq_o_data_muxed7[3]),
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o7)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed7[0]),
+	.D1      (ddrphy_dq_o_data_muxed7[1]),
+	.D2      (ddrphy_dq_o_data_muxed7[2]),
+	.D3      (ddrphy_dq_o_data_muxed7[3]),
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o7)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_31 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_31 (
-	.A(ddrphy_dq_i7),
-	.Z(ddrphy_dq_i_delayed7)
+	// Inputs.
+	.A (ddrphy_dq_i7),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed7)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_7 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_7(
-	.D(ddrphy_dq_i_delayed7),
-	.DQSR90(ddrphy_dqsr900),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr0[0]),
-	.RDPNTR1(ddrphy_rdpntr0[1]),
-	.RDPNTR2(ddrphy_rdpntr0[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr0[0]),
-	.WRPNTR1(ddrphy_wrpntr0[1]),
-	.WRPNTR2(ddrphy_wrpntr0[2]),
-	.Q0(ddrphy_bitslip7_i[0]),
-	.Q1(ddrphy_bitslip7_i[1]),
-	.Q2(ddrphy_bitslip7_i[2]),
-	.Q3(ddrphy_bitslip7_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed7),
+	.DQSR90  (ddrphy_dqsr900),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr0[0]),
+	.RDPNTR1 (ddrphy_rdpntr0[1]),
+	.RDPNTR2 (ddrphy_rdpntr0[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr0[0]),
+	.WRPNTR1 (ddrphy_wrpntr0[1]),
+	.WRPNTR2 (ddrphy_wrpntr0[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip7_i[0]),
+	.Q1      (ddrphy_bitslip7_i[1]),
+	.Q2      (ddrphy_bitslip7_i[2]),
+	.Q3      (ddrphy_bitslip7_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_7 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_7(
-	.DQSW270(ddrphy_dqsw2700),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n7)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2700),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n7)
 );
 
+//------------------------------------------------------------------------------
+// Instance DQSBUFM_1 of DQSBUFM Module.
+//------------------------------------------------------------------------------
 DQSBUFM #(
-	.DQS_LI_DEL_ADJ("MINUS"),
-	.DQS_LI_DEL_VAL(1'd1),
-	.DQS_LO_DEL_ADJ("MINUS"),
-	.DQS_LO_DEL_VAL(3'd4)
+	// Parameters.
+	.DQS_LI_DEL_ADJ ("MINUS"),
+	.DQS_LI_DEL_VAL (1'd1),
+	.DQS_LO_DEL_ADJ ("MINUS"),
+	.DQS_LO_DEL_VAL (3'd4)
 ) DQSBUFM_1 (
-	.DDRDEL(ddrphy_delay0),
-	.DQSI(ddrphy_dqs_i1),
-	.ECLK(sys2x_clk),
-	.PAUSE((ddrphy_pause0 | ddrphy_dly_sel_storage[1])),
-	.RDDIRECTION(1'd1),
-	.RDLOADN(1'd0),
-	.RDMOVE(1'd0),
-	.READ0(ddrphy_dqs_re),
-	.READ1(ddrphy_dqs_re),
-	.READCLKSEL0(ddrphy_rdly1[0]),
-	.READCLKSEL1(ddrphy_rdly1[1]),
-	.READCLKSEL2(ddrphy_rdly1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRDIRECTION(1'd1),
-	.WRLOADN(1'd0),
-	.WRMOVE(1'd0),
-	.BURSTDET(ddrphy_burstdet1),
-	.DATAVALID(ddrphy_datavalid[1]),
-	.DQSR90(ddrphy_dqsr901),
-	.DQSW(ddrphy_dqsw1),
-	.DQSW270(ddrphy_dqsw2701),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2])
+	// Inputs.
+	.DDRDEL      (ddrphy_delay0),
+	.DQSI        (ddrphy_dqs_i1),
+	.ECLK        (sys2x_clk),
+	.PAUSE       ((ddrphy_pause0 | ddrphy_dly_sel_storage[1])),
+	.RDDIRECTION (1'd1),
+	.RDLOADN     (1'd0),
+	.RDMOVE      (1'd0),
+	.READ0       (ddrphy_dqs_re),
+	.READ1       (ddrphy_dqs_re),
+	.READCLKSEL0 (ddrphy_rdly1[0]),
+	.READCLKSEL1 (ddrphy_rdly1[1]),
+	.READCLKSEL2 (ddrphy_rdly1[2]),
+	.RST         (sys_rst),
+	.SCLK        (sys_clk),
+	.WRDIRECTION (1'd1),
+	.WRLOADN     (1'd0),
+	.WRMOVE      (1'd0),
+
+	// Outputs.
+	.BURSTDET    (ddrphy_burstdet1),
+	.DATAVALID   (ddrphy_datavalid[1]),
+	.DQSR90      (ddrphy_dqsr901),
+	.DQSW        (ddrphy_dqsw1),
+	.DQSW270     (ddrphy_dqsw2701),
+	.RDPNTR0     (ddrphy_rdpntr1[0]),
+	.RDPNTR1     (ddrphy_rdpntr1[1]),
+	.RDPNTR2     (ddrphy_rdpntr1[2]),
+	.WRPNTR0     (ddrphy_wrpntr1[0]),
+	.WRPNTR1     (ddrphy_wrpntr1[1]),
+	.WRPNTR2     (ddrphy_wrpntr1[2])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQSB_1 of ODDRX2DQSB Module.
+//------------------------------------------------------------------------------
 ODDRX2DQSB ODDRX2DQSB_1(
-	.D0(1'd0),
-	.D1(1'd1),
-	.D2(1'd0),
-	.D3(1'd1),
-	.DQSW(ddrphy_dqsw1),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dqs1)
+	// Inputs.
+	.D0   (1'd0),
+	.D1   (1'd1),
+	.D2   (1'd0),
+	.D3   (1'd1),
+	.DQSW (ddrphy_dqsw1),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+
+	// Outputs.
+	.Q    (ddrphy_dqs1)
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQSA_1 of TSHX2DQSA Module.
+//------------------------------------------------------------------------------
 TSHX2DQSA TSHX2DQSA_1(
-	.DQSW(ddrphy_dqsw1),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~(ddrphy_dqs_oe | ddrphy_dqs_postamble))),
-	.T1((~(ddrphy_dqs_oe | ddrphy_dqs_preamble))),
-	.Q(ddrphy_dqs_oe_n1)
+	// Inputs.
+	.DQSW (ddrphy_dqsw1),
+	.ECLK (sys2x_clk),
+	.RST  (sys_rst),
+	.SCLK (sys_clk),
+	.T0   ((~(ddrphy_dqs_oe | ddrphy_dqs_postamble))),
+	.T1   ((~(ddrphy_dqs_oe | ddrphy_dqs_preamble))),
+
+	// Outputs.
+	.Q    (ddrphy_dqs_oe_n1)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_9 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_9(
-	.D0(ddrphy_dm_o_data_muxed1[0]),
-	.D1(ddrphy_dm_o_data_muxed1[1]),
-	.D2(ddrphy_dm_o_data_muxed1[2]),
-	.D3(ddrphy_dm_o_data_muxed1[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddram_dm[1])
+	// Inputs.
+	.D0      (ddrphy_dm_o_data_muxed1[0]),
+	.D1      (ddrphy_dm_o_data_muxed1[1]),
+	.D2      (ddrphy_dm_o_data_muxed1[2]),
+	.D3      (ddrphy_dm_o_data_muxed1[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddram_dm[1])
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_10 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_10(
-	.D0(ddrphy_dq_o_data_muxed8[0]),
-	.D1(ddrphy_dq_o_data_muxed8[1]),
-	.D2(ddrphy_dq_o_data_muxed8[2]),
-	.D3(ddrphy_dq_o_data_muxed8[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o8)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed8[0]),
+	.D1      (ddrphy_dq_o_data_muxed8[1]),
+	.D2      (ddrphy_dq_o_data_muxed8[2]),
+	.D3      (ddrphy_dq_o_data_muxed8[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o8)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_32 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_32 (
-	.A(ddrphy_dq_i8),
-	.Z(ddrphy_dq_i_delayed8)
+	// Inputs.
+	.A (ddrphy_dq_i8),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed8)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_8 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_8(
-	.D(ddrphy_dq_i_delayed8),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip8_i[0]),
-	.Q1(ddrphy_bitslip8_i[1]),
-	.Q2(ddrphy_bitslip8_i[2]),
-	.Q3(ddrphy_bitslip8_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed8),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip8_i[0]),
+	.Q1      (ddrphy_bitslip8_i[1]),
+	.Q2      (ddrphy_bitslip8_i[2]),
+	.Q3      (ddrphy_bitslip8_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_8 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_8(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n8)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n8)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_11 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_11(
-	.D0(ddrphy_dq_o_data_muxed9[0]),
-	.D1(ddrphy_dq_o_data_muxed9[1]),
-	.D2(ddrphy_dq_o_data_muxed9[2]),
-	.D3(ddrphy_dq_o_data_muxed9[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o9)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed9[0]),
+	.D1      (ddrphy_dq_o_data_muxed9[1]),
+	.D2      (ddrphy_dq_o_data_muxed9[2]),
+	.D3      (ddrphy_dq_o_data_muxed9[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o9)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_33 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_33 (
-	.A(ddrphy_dq_i9),
-	.Z(ddrphy_dq_i_delayed9)
+	// Inputs.
+	.A (ddrphy_dq_i9),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed9)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_9 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_9(
-	.D(ddrphy_dq_i_delayed9),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip9_i[0]),
-	.Q1(ddrphy_bitslip9_i[1]),
-	.Q2(ddrphy_bitslip9_i[2]),
-	.Q3(ddrphy_bitslip9_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed9),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip9_i[0]),
+	.Q1      (ddrphy_bitslip9_i[1]),
+	.Q2      (ddrphy_bitslip9_i[2]),
+	.Q3      (ddrphy_bitslip9_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_9 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_9(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n9)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n9)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_12 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_12(
-	.D0(ddrphy_dq_o_data_muxed10[0]),
-	.D1(ddrphy_dq_o_data_muxed10[1]),
-	.D2(ddrphy_dq_o_data_muxed10[2]),
-	.D3(ddrphy_dq_o_data_muxed10[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o10)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed10[0]),
+	.D1      (ddrphy_dq_o_data_muxed10[1]),
+	.D2      (ddrphy_dq_o_data_muxed10[2]),
+	.D3      (ddrphy_dq_o_data_muxed10[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o10)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_34 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_34 (
-	.A(ddrphy_dq_i10),
-	.Z(ddrphy_dq_i_delayed10)
+	// Inputs.
+	.A (ddrphy_dq_i10),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed10)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_10 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_10(
-	.D(ddrphy_dq_i_delayed10),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip10_i[0]),
-	.Q1(ddrphy_bitslip10_i[1]),
-	.Q2(ddrphy_bitslip10_i[2]),
-	.Q3(ddrphy_bitslip10_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed10),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip10_i[0]),
+	.Q1      (ddrphy_bitslip10_i[1]),
+	.Q2      (ddrphy_bitslip10_i[2]),
+	.Q3      (ddrphy_bitslip10_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_10 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_10(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n10)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n10)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_13 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_13(
-	.D0(ddrphy_dq_o_data_muxed11[0]),
-	.D1(ddrphy_dq_o_data_muxed11[1]),
-	.D2(ddrphy_dq_o_data_muxed11[2]),
-	.D3(ddrphy_dq_o_data_muxed11[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o11)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed11[0]),
+	.D1      (ddrphy_dq_o_data_muxed11[1]),
+	.D2      (ddrphy_dq_o_data_muxed11[2]),
+	.D3      (ddrphy_dq_o_data_muxed11[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o11)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_35 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_35 (
-	.A(ddrphy_dq_i11),
-	.Z(ddrphy_dq_i_delayed11)
+	// Inputs.
+	.A (ddrphy_dq_i11),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed11)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_11 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_11(
-	.D(ddrphy_dq_i_delayed11),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip11_i[0]),
-	.Q1(ddrphy_bitslip11_i[1]),
-	.Q2(ddrphy_bitslip11_i[2]),
-	.Q3(ddrphy_bitslip11_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed11),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip11_i[0]),
+	.Q1      (ddrphy_bitslip11_i[1]),
+	.Q2      (ddrphy_bitslip11_i[2]),
+	.Q3      (ddrphy_bitslip11_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_11 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_11(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n11)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n11)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_14 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_14(
-	.D0(ddrphy_dq_o_data_muxed12[0]),
-	.D1(ddrphy_dq_o_data_muxed12[1]),
-	.D2(ddrphy_dq_o_data_muxed12[2]),
-	.D3(ddrphy_dq_o_data_muxed12[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o12)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed12[0]),
+	.D1      (ddrphy_dq_o_data_muxed12[1]),
+	.D2      (ddrphy_dq_o_data_muxed12[2]),
+	.D3      (ddrphy_dq_o_data_muxed12[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o12)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_36 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_36 (
-	.A(ddrphy_dq_i12),
-	.Z(ddrphy_dq_i_delayed12)
+	// Inputs.
+	.A (ddrphy_dq_i12),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed12)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_12 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_12(
-	.D(ddrphy_dq_i_delayed12),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip12_i[0]),
-	.Q1(ddrphy_bitslip12_i[1]),
-	.Q2(ddrphy_bitslip12_i[2]),
-	.Q3(ddrphy_bitslip12_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed12),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip12_i[0]),
+	.Q1      (ddrphy_bitslip12_i[1]),
+	.Q2      (ddrphy_bitslip12_i[2]),
+	.Q3      (ddrphy_bitslip12_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_12 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_12(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n12)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n12)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_15 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_15(
-	.D0(ddrphy_dq_o_data_muxed13[0]),
-	.D1(ddrphy_dq_o_data_muxed13[1]),
-	.D2(ddrphy_dq_o_data_muxed13[2]),
-	.D3(ddrphy_dq_o_data_muxed13[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o13)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed13[0]),
+	.D1      (ddrphy_dq_o_data_muxed13[1]),
+	.D2      (ddrphy_dq_o_data_muxed13[2]),
+	.D3      (ddrphy_dq_o_data_muxed13[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o13)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_37 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_37 (
-	.A(ddrphy_dq_i13),
-	.Z(ddrphy_dq_i_delayed13)
+	// Inputs.
+	.A (ddrphy_dq_i13),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed13)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_13 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_13(
-	.D(ddrphy_dq_i_delayed13),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip13_i[0]),
-	.Q1(ddrphy_bitslip13_i[1]),
-	.Q2(ddrphy_bitslip13_i[2]),
-	.Q3(ddrphy_bitslip13_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed13),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip13_i[0]),
+	.Q1      (ddrphy_bitslip13_i[1]),
+	.Q2      (ddrphy_bitslip13_i[2]),
+	.Q3      (ddrphy_bitslip13_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_13 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_13(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n13)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n13)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_16 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_16(
-	.D0(ddrphy_dq_o_data_muxed14[0]),
-	.D1(ddrphy_dq_o_data_muxed14[1]),
-	.D2(ddrphy_dq_o_data_muxed14[2]),
-	.D3(ddrphy_dq_o_data_muxed14[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o14)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed14[0]),
+	.D1      (ddrphy_dq_o_data_muxed14[1]),
+	.D2      (ddrphy_dq_o_data_muxed14[2]),
+	.D3      (ddrphy_dq_o_data_muxed14[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o14)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_38 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_38 (
-	.A(ddrphy_dq_i14),
-	.Z(ddrphy_dq_i_delayed14)
+	// Inputs.
+	.A (ddrphy_dq_i14),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed14)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_14 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_14(
-	.D(ddrphy_dq_i_delayed14),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip14_i[0]),
-	.Q1(ddrphy_bitslip14_i[1]),
-	.Q2(ddrphy_bitslip14_i[2]),
-	.Q3(ddrphy_bitslip14_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed14),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip14_i[0]),
+	.Q1      (ddrphy_bitslip14_i[1]),
+	.Q2      (ddrphy_bitslip14_i[2]),
+	.Q3      (ddrphy_bitslip14_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_14 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_14(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n14)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n14)
 );
 
+//------------------------------------------------------------------------------
+// Instance ODDRX2DQA_17 of ODDRX2DQA Module.
+//------------------------------------------------------------------------------
 ODDRX2DQA ODDRX2DQA_17(
-	.D0(ddrphy_dq_o_data_muxed15[0]),
-	.D1(ddrphy_dq_o_data_muxed15[1]),
-	.D2(ddrphy_dq_o_data_muxed15[2]),
-	.D3(ddrphy_dq_o_data_muxed15[3]),
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.Q(ddrphy_dq_o15)
+	// Inputs.
+	.D0      (ddrphy_dq_o_data_muxed15[0]),
+	.D1      (ddrphy_dq_o_data_muxed15[1]),
+	.D2      (ddrphy_dq_o_data_muxed15[2]),
+	.D3      (ddrphy_dq_o_data_muxed15[3]),
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+
+	// Outputs.
+	.Q       (ddrphy_dq_o15)
 );
 
+//------------------------------------------------------------------------------
+// Instance DELAYG_39 of DELAYG Module.
+//------------------------------------------------------------------------------
 DELAYG #(
-	.DEL_MODE("DQS_ALIGNED_X2")
+	// Parameters.
+	.DEL_MODE ("DQS_ALIGNED_X2")
 ) DELAYG_39 (
-	.A(ddrphy_dq_i15),
-	.Z(ddrphy_dq_i_delayed15)
+	// Inputs.
+	.A (ddrphy_dq_i15),
+
+	// Outputs.
+	.Z (ddrphy_dq_i_delayed15)
 );
 
+//------------------------------------------------------------------------------
+// Instance IDDRX2DQA_15 of IDDRX2DQA Module.
+//------------------------------------------------------------------------------
 IDDRX2DQA IDDRX2DQA_15(
-	.D(ddrphy_dq_i_delayed15),
-	.DQSR90(ddrphy_dqsr901),
-	.ECLK(sys2x_clk),
-	.RDPNTR0(ddrphy_rdpntr1[0]),
-	.RDPNTR1(ddrphy_rdpntr1[1]),
-	.RDPNTR2(ddrphy_rdpntr1[2]),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.WRPNTR0(ddrphy_wrpntr1[0]),
-	.WRPNTR1(ddrphy_wrpntr1[1]),
-	.WRPNTR2(ddrphy_wrpntr1[2]),
-	.Q0(ddrphy_bitslip15_i[0]),
-	.Q1(ddrphy_bitslip15_i[1]),
-	.Q2(ddrphy_bitslip15_i[2]),
-	.Q3(ddrphy_bitslip15_i[3])
+	// Inputs.
+	.D       (ddrphy_dq_i_delayed15),
+	.DQSR90  (ddrphy_dqsr901),
+	.ECLK    (sys2x_clk),
+	.RDPNTR0 (ddrphy_rdpntr1[0]),
+	.RDPNTR1 (ddrphy_rdpntr1[1]),
+	.RDPNTR2 (ddrphy_rdpntr1[2]),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.WRPNTR0 (ddrphy_wrpntr1[0]),
+	.WRPNTR1 (ddrphy_wrpntr1[1]),
+	.WRPNTR2 (ddrphy_wrpntr1[2]),
+
+	// Outputs.
+	.Q0      (ddrphy_bitslip15_i[0]),
+	.Q1      (ddrphy_bitslip15_i[1]),
+	.Q2      (ddrphy_bitslip15_i[2]),
+	.Q3      (ddrphy_bitslip15_i[3])
 );
 
+//------------------------------------------------------------------------------
+// Instance TSHX2DQA_15 of TSHX2DQA Module.
+//------------------------------------------------------------------------------
 TSHX2DQA TSHX2DQA_15(
-	.DQSW270(ddrphy_dqsw2701),
-	.ECLK(sys2x_clk),
-	.RST(sys_rst),
-	.SCLK(sys_clk),
-	.T0((~ddrphy_dq_oe)),
-	.T1((~ddrphy_dq_oe)),
-	.Q(ddrphy_dq_oe_n15)
+	// Inputs.
+	.DQSW270 (ddrphy_dqsw2701),
+	.ECLK    (sys2x_clk),
+	.RST     (sys_rst),
+	.SCLK    (sys_clk),
+	.T0      ((~ddrphy_dq_oe)),
+	.T1      ((~ddrphy_dq_oe)),
+
+	// Outputs.
+	.Q       (ddrphy_dq_oe_n15)
 );
 
 //------------------------------------------------------------------------------
@@ -14428,252 +15215,433 @@ assign litedramnativeportconverter_wdata_fifo_rdport_dat_r = storage_9[litedramn
 
 
 (* FREQUENCY_PIN_CLKI = "48.0", FREQUENCY_PIN_CLKOP = "100.0", FREQUENCY_PIN_CLKOS = "25.0", ICP_CURRENT = "6", LPF_RESISTOR = "16", MFG_ENABLE_FILTEROPAMP = "1", MFG_GMCREF_SEL = "2" *)
+//------------------------------------------------------------------------------
+// Instance EHXPLLL of EHXPLLL Module.
+//------------------------------------------------------------------------------
 EHXPLLL #(
-	.CLKFB_DIV(5'd21),
-	.CLKI_DIV(2'd2),
-	.CLKOP_CPHASE(3'd4),
-	.CLKOP_DIV(3'd5),
-	.CLKOP_ENABLE("ENABLED"),
-	.CLKOP_FPHASE(1'd0),
-	.CLKOS2_CPHASE(1'd0),
-	.CLKOS2_DIV(1'd1),
-	.CLKOS2_ENABLE("ENABLED"),
-	.CLKOS2_FPHASE(1'd0),
-	.CLKOS_CPHASE(5'd19),
-	.CLKOS_DIV(5'd20),
-	.CLKOS_ENABLE("ENABLED"),
-	.CLKOS_FPHASE(1'd0),
-	.FEEDBK_PATH("INT_OS2")
+	// Parameters.
+	.CLKFB_DIV     (5'd21),
+	.CLKI_DIV      (2'd2),
+	.CLKOP_CPHASE  (3'd4),
+	.CLKOP_DIV     (3'd5),
+	.CLKOP_ENABLE  ("ENABLED"),
+	.CLKOP_FPHASE  (1'd0),
+	.CLKOS2_CPHASE (1'd0),
+	.CLKOS2_DIV    (1'd1),
+	.CLKOS2_ENABLE ("ENABLED"),
+	.CLKOS2_FPHASE (1'd0),
+	.CLKOS_CPHASE  (5'd19),
+	.CLKOS_DIV     (5'd20),
+	.CLKOS_ENABLE  ("ENABLED"),
+	.CLKOS_FPHASE  (1'd0),
+	.FEEDBK_PATH   ("INT_OS2")
 ) EHXPLLL (
-	.CLKI(crg_clkin),
-	.RST(crg_reset1),
-	.STDBY(crg_stdby),
-	.CLKOP(crg_clkout0),
-	.CLKOS(crg_clkout1),
-	.CLKOS2(litedramcore_litedramecp5ddrphycrg_ecp5pll),
-	.LOCK(litedramcore_litedramecp5ddrphycrg_locked)
+	// Inputs.
+	.CLKI   (crg_clkin),
+	.RST    (crg_reset1),
+	.STDBY  (crg_stdby),
+
+	// Outputs.
+	.CLKOP  (crg_clkout0),
+	.CLKOS  (crg_clkout1),
+	.CLKOS2 (litedramcore_litedramecp5ddrphycrg_ecp5pll),
+	.LOCK   (litedramcore_litedramecp5ddrphycrg_locked)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX(
-	.CK(sys2x_i_clk),
-	.D(1'd0),
-	.PD((~crg_locked)),
-	.Q(latticeecp5asyncresetsynchronizerimpl0_rst1)
+	// Inputs.
+	.CK (sys2x_i_clk),
+	.D  (1'd0),
+	.PD ((~crg_locked)),
+
+	// Outputs.
+	.Q  (latticeecp5asyncresetsynchronizerimpl0_rst1)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_1 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_1(
-	.CK(sys2x_i_clk),
-	.D(latticeecp5asyncresetsynchronizerimpl0_rst1),
-	.PD((~crg_locked)),
-	.Q(latticeecp5asyncresetsynchronizerimpl0_expr)
+	// Inputs.
+	.CK (sys2x_i_clk),
+	.D  (latticeecp5asyncresetsynchronizerimpl0_rst1),
+	.PD ((~crg_locked)),
+
+	// Outputs.
+	.Q  (latticeecp5asyncresetsynchronizerimpl0_expr)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_2 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_2(
-	.CK(init_clk),
-	.D(1'd0),
-	.PD((~crg_locked)),
-	.Q(latticeecp5asyncresetsynchronizerimpl1_rst1)
+	// Inputs.
+	.CK (init_clk),
+	.D  (1'd0),
+	.PD ((~crg_locked)),
+
+	// Outputs.
+	.Q  (latticeecp5asyncresetsynchronizerimpl1_rst1)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_3 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_3(
-	.CK(init_clk),
-	.D(latticeecp5asyncresetsynchronizerimpl1_rst1),
-	.PD((~crg_locked)),
-	.Q(init_rst)
+	// Inputs.
+	.CK (init_clk),
+	.D  (latticeecp5asyncresetsynchronizerimpl1_rst1),
+	.PD ((~crg_locked)),
+
+	// Outputs.
+	.Q  (init_rst)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_4 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_4(
-	.CK(sys_clk),
-	.D(1'd0),
-	.PD(((~crg_locked) | crg_reset0)),
-	.Q(latticeecp5asyncresetsynchronizerimpl2_rst1)
+	// Inputs.
+	.CK (sys_clk),
+	.D  (1'd0),
+	.PD (((~crg_locked) | crg_reset0)),
+
+	// Outputs.
+	.Q  (latticeecp5asyncresetsynchronizerimpl2_rst1)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_5 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_5(
-	.CK(sys_clk),
-	.D(latticeecp5asyncresetsynchronizerimpl2_rst1),
-	.PD(((~crg_locked) | crg_reset0)),
-	.Q(sys_rst)
+	// Inputs.
+	.CK (sys_clk),
+	.D  (latticeecp5asyncresetsynchronizerimpl2_rst1),
+	.PD (((~crg_locked) | crg_reset0)),
+
+	// Outputs.
+	.Q  (sys_rst)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_6 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_6(
-	.CK(sys2x_clk),
-	.D(1'd0),
-	.PD(((~crg_locked) | crg_reset0)),
-	.Q(latticeecp5asyncresetsynchronizerimpl3_rst1)
+	// Inputs.
+	.CK (sys2x_clk),
+	.D  (1'd0),
+	.PD (((~crg_locked) | crg_reset0)),
+
+	// Outputs.
+	.Q  (latticeecp5asyncresetsynchronizerimpl3_rst1)
 );
 
+//------------------------------------------------------------------------------
+// Instance FD1S3BX_7 of FD1S3BX Module.
+//------------------------------------------------------------------------------
 FD1S3BX FD1S3BX_7(
-	.CK(sys2x_clk),
-	.D(latticeecp5asyncresetsynchronizerimpl3_rst1),
-	.PD(((~crg_locked) | crg_reset0)),
-	.Q(sys2x_rst)
+	// Inputs.
+	.CK (sys2x_clk),
+	.D  (latticeecp5asyncresetsynchronizerimpl3_rst1),
+	.PD (((~crg_locked) | crg_reset0)),
+
+	// Outputs.
+	.Q  (sys2x_rst)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO (
-	.B(ddram_dqs_p[0]),
-	.I(ddrphy_dqs0),
-	.T((~(~ddrphy_dqs_oe_n0))),
-	.O(ddrphy_dqs_i0)
+	// Inputs.
+	.B (ddram_dqs_p[0]),
+	.I (ddrphy_dqs0),
+	.T ((~(~ddrphy_dqs_oe_n0))),
+
+	// Outputs.
+	.O (ddrphy_dqs_i0)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_1 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_1 (
-	.B(ddram_dq[0]),
-	.I(ddrphy_dq_o0),
-	.T((~(~ddrphy_dq_oe_n0))),
-	.O(ddrphy_dq_i0)
+	// Inputs.
+	.B (ddram_dq[0]),
+	.I (ddrphy_dq_o0),
+	.T ((~(~ddrphy_dq_oe_n0))),
+
+	// Outputs.
+	.O (ddrphy_dq_i0)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_2 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_2 (
-	.B(ddram_dq[1]),
-	.I(ddrphy_dq_o1),
-	.T((~(~ddrphy_dq_oe_n1))),
-	.O(ddrphy_dq_i1)
+	// Inputs.
+	.B (ddram_dq[1]),
+	.I (ddrphy_dq_o1),
+	.T ((~(~ddrphy_dq_oe_n1))),
+
+	// Outputs.
+	.O (ddrphy_dq_i1)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_3 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_3 (
-	.B(ddram_dq[2]),
-	.I(ddrphy_dq_o2),
-	.T((~(~ddrphy_dq_oe_n2))),
-	.O(ddrphy_dq_i2)
+	// Inputs.
+	.B (ddram_dq[2]),
+	.I (ddrphy_dq_o2),
+	.T ((~(~ddrphy_dq_oe_n2))),
+
+	// Outputs.
+	.O (ddrphy_dq_i2)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_4 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_4 (
-	.B(ddram_dq[3]),
-	.I(ddrphy_dq_o3),
-	.T((~(~ddrphy_dq_oe_n3))),
-	.O(ddrphy_dq_i3)
+	// Inputs.
+	.B (ddram_dq[3]),
+	.I (ddrphy_dq_o3),
+	.T ((~(~ddrphy_dq_oe_n3))),
+
+	// Outputs.
+	.O (ddrphy_dq_i3)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_5 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_5 (
-	.B(ddram_dq[4]),
-	.I(ddrphy_dq_o4),
-	.T((~(~ddrphy_dq_oe_n4))),
-	.O(ddrphy_dq_i4)
+	// Inputs.
+	.B (ddram_dq[4]),
+	.I (ddrphy_dq_o4),
+	.T ((~(~ddrphy_dq_oe_n4))),
+
+	// Outputs.
+	.O (ddrphy_dq_i4)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_6 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_6 (
-	.B(ddram_dq[5]),
-	.I(ddrphy_dq_o5),
-	.T((~(~ddrphy_dq_oe_n5))),
-	.O(ddrphy_dq_i5)
+	// Inputs.
+	.B (ddram_dq[5]),
+	.I (ddrphy_dq_o5),
+	.T ((~(~ddrphy_dq_oe_n5))),
+
+	// Outputs.
+	.O (ddrphy_dq_i5)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_7 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_7 (
-	.B(ddram_dq[6]),
-	.I(ddrphy_dq_o6),
-	.T((~(~ddrphy_dq_oe_n6))),
-	.O(ddrphy_dq_i6)
+	// Inputs.
+	.B (ddram_dq[6]),
+	.I (ddrphy_dq_o6),
+	.T ((~(~ddrphy_dq_oe_n6))),
+
+	// Outputs.
+	.O (ddrphy_dq_i6)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_8 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_8 (
-	.B(ddram_dq[7]),
-	.I(ddrphy_dq_o7),
-	.T((~(~ddrphy_dq_oe_n7))),
-	.O(ddrphy_dq_i7)
+	// Inputs.
+	.B (ddram_dq[7]),
+	.I (ddrphy_dq_o7),
+	.T ((~(~ddrphy_dq_oe_n7))),
+
+	// Outputs.
+	.O (ddrphy_dq_i7)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_9 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_9 (
-	.B(ddram_dqs_p[1]),
-	.I(ddrphy_dqs1),
-	.T((~(~ddrphy_dqs_oe_n1))),
-	.O(ddrphy_dqs_i1)
+	// Inputs.
+	.B (ddram_dqs_p[1]),
+	.I (ddrphy_dqs1),
+	.T ((~(~ddrphy_dqs_oe_n1))),
+
+	// Outputs.
+	.O (ddrphy_dqs_i1)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_10 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_10 (
-	.B(ddram_dq[8]),
-	.I(ddrphy_dq_o8),
-	.T((~(~ddrphy_dq_oe_n8))),
-	.O(ddrphy_dq_i8)
+	// Inputs.
+	.B (ddram_dq[8]),
+	.I (ddrphy_dq_o8),
+	.T ((~(~ddrphy_dq_oe_n8))),
+
+	// Outputs.
+	.O (ddrphy_dq_i8)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_11 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_11 (
-	.B(ddram_dq[9]),
-	.I(ddrphy_dq_o9),
-	.T((~(~ddrphy_dq_oe_n9))),
-	.O(ddrphy_dq_i9)
+	// Inputs.
+	.B (ddram_dq[9]),
+	.I (ddrphy_dq_o9),
+	.T ((~(~ddrphy_dq_oe_n9))),
+
+	// Outputs.
+	.O (ddrphy_dq_i9)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_12 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_12 (
-	.B(ddram_dq[10]),
-	.I(ddrphy_dq_o10),
-	.T((~(~ddrphy_dq_oe_n10))),
-	.O(ddrphy_dq_i10)
+	// Inputs.
+	.B (ddram_dq[10]),
+	.I (ddrphy_dq_o10),
+	.T ((~(~ddrphy_dq_oe_n10))),
+
+	// Outputs.
+	.O (ddrphy_dq_i10)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_13 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_13 (
-	.B(ddram_dq[11]),
-	.I(ddrphy_dq_o11),
-	.T((~(~ddrphy_dq_oe_n11))),
-	.O(ddrphy_dq_i11)
+	// Inputs.
+	.B (ddram_dq[11]),
+	.I (ddrphy_dq_o11),
+	.T ((~(~ddrphy_dq_oe_n11))),
+
+	// Outputs.
+	.O (ddrphy_dq_i11)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_14 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_14 (
-	.B(ddram_dq[12]),
-	.I(ddrphy_dq_o12),
-	.T((~(~ddrphy_dq_oe_n12))),
-	.O(ddrphy_dq_i12)
+	// Inputs.
+	.B (ddram_dq[12]),
+	.I (ddrphy_dq_o12),
+	.T ((~(~ddrphy_dq_oe_n12))),
+
+	// Outputs.
+	.O (ddrphy_dq_i12)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_15 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_15 (
-	.B(ddram_dq[13]),
-	.I(ddrphy_dq_o13),
-	.T((~(~ddrphy_dq_oe_n13))),
-	.O(ddrphy_dq_i13)
+	// Inputs.
+	.B (ddram_dq[13]),
+	.I (ddrphy_dq_o13),
+	.T ((~(~ddrphy_dq_oe_n13))),
+
+	// Outputs.
+	.O (ddrphy_dq_i13)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_16 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_16 (
-	.B(ddram_dq[14]),
-	.I(ddrphy_dq_o14),
-	.T((~(~ddrphy_dq_oe_n14))),
-	.O(ddrphy_dq_i14)
+	// Inputs.
+	.B (ddram_dq[14]),
+	.I (ddrphy_dq_o14),
+	.T ((~(~ddrphy_dq_oe_n14))),
+
+	// Outputs.
+	.O (ddrphy_dq_i14)
 );
 
+//------------------------------------------------------------------------------
+// Instance TRELLIS_IO_17 of TRELLIS_IO Module.
+//------------------------------------------------------------------------------
 TRELLIS_IO #(
-	.DIR("BIDIR")
+	// Parameters.
+	.DIR ("BIDIR")
 ) TRELLIS_IO_17 (
-	.B(ddram_dq[15]),
-	.I(ddrphy_dq_o15),
-	.T((~(~ddrphy_dq_oe_n15))),
-	.O(ddrphy_dq_i15)
+	// Inputs.
+	.B (ddram_dq[15]),
+	.I (ddrphy_dq_o15),
+	.T ((~(~ddrphy_dq_oe_n15))),
+
+	// Outputs.
+	.O (ddrphy_dq_i15)
 );
 
 endmodule
 
 // -----------------------------------------------------------------------------
-//  Auto-Generated by LiteX on 2023-11-06 17:52:25.
+//  Auto-Generated by LiteX on 2023-11-17 12:10:32.
 //------------------------------------------------------------------------------

--- a/fpga/orangecrab_litedram/orangecrab.yml
+++ b/fpga/orangecrab_litedram/orangecrab.yml
@@ -19,6 +19,7 @@
     "sdram_module_nb": 2,             # Number of byte groups
     "sdram_rank_nb":   1,             # Number of ranks
     "sdram_phy":       "ECP5DDRPHY",  # Type of FPGA PHY
+    "dm_swap":          true,
 
     # Frequency ----------------------------------------------------------------
     "input_clk_freq":   48e6,  # Input clock frequency


### PR DESCRIPTION
DM swap is required for DRAM to work properly on OrangeCrab due to swapped LDM/UDM lines on the board.

See https://github.com/litex-hub/linux-on-litex-vexriscv/issues/174#issuecomment-759257488